### PR TITLE
Build `libarchive' from sources due to a memory leak in 3.1.2 which

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,8 @@
 [submodule "freetype2"]
-	path = external/freetype2
-	url = http://git.sv.nongnu.org/r/freetype/freetype2.git
-	branch = master
+  path = external/freetype2
+  url = http://git.sv.nongnu.org/r/freetype/freetype2.git
+  branch = master
+[submodule "libarchive"]
+  path = external/libarchive
+  url = https://github.com/libarchive/libarchive.git
+  branch = master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - TRAVIS_CI_ROW="fuzzing"
 
 before_install:
-  - sudo apt-get -qq update && sudo apt-get install -y autoconf cmake libarchive-dev libgoogle-glog-dev libtool
+  - sudo apt-get -qq update && sudo apt-get install -y autoconf cmake libgoogle-glog-dev libtool
   - eval "${MATRIX_EVAL}"
 
 script:

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -23,6 +23,10 @@ set(FREETYPE_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../external/freetype2")
 set(FREETYPE_SRC_DIR        "${FREETYPE_BASE_DIR}/src")
 set(FREETYPE_STATIC_LIBRARY "${FREETYPE_BASE_DIR}/objs/.libs/libfreetype.a")
 
+set(LIBARCHIVE_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../external/libarchive")
+set(LIBARCHIVE_SRC_DIR        "${LIBARCHIVE_BASE_DIR}/src")
+set(LIBARCHIVE_STATIC_LIBRARY "${LIBARCHIVE_BASE_DIR}/.libs/libarchive.a")
+
 set(FUZZING_BASE_DIR "${CMAKE_CURRENT_SOURCE_DIR}")
 set(FUZZING_SRC_DIR  "${FUZZING_BASE_DIR}/src")
 
@@ -37,8 +41,10 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-include_directories("${FREETYPE_BASE_DIR}/include")
-include_directories("${FUZZING_SRC_DIR}")
+include_directories(
+  "${FREETYPE_BASE_DIR}/include"
+  "${FUZZING_SRC_DIR}"
+  "${LIBARCHIVE_BASE_DIR}/libarchive")
 
 link_directories("${FREETYPE_BASE_DIR}/objs/.libs")
 

--- a/fuzzing/scripts/build-fuzzers.sh
+++ b/fuzzing/scripts/build-fuzzers.sh
@@ -21,6 +21,8 @@ cd "${0%/*}" # go to `fuzzing/scripts'
 # which would cause CMake's setup process to fail.  See
 # `fuzzing/src/fuzzing/CMakeLists.txt' for details.
 
+bash build-libarchive.sh
+
 bash build-freetype.sh
 
 bash build-targets.sh

--- a/fuzzing/scripts/build-libarchive.sh
+++ b/fuzzing/scripts/build-libarchive.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+set -euxo pipefail
+
+# Copyright 2018 by
+# Armin Hasitzka.
+#
+# This file is part of the FreeType project, and may only be used, modified,
+# and distributed under the terms of the FreeType project license,
+# LICENSE.TXT.  By continuing to use, modify, or distribute this file you
+# indicate that you have read the license and understand and accept it
+# fully.
+
+dir="${PWD}"
+pathToLibarchive=$(readlink -f "../../external/libarchive")
+
+git submodule init   "${pathToLibarchive}"
+git submodule update "${pathToLibarchive}"
+
+cd "${pathToLibarchive}"
+
+git clean -dfqx
+git reset --hard
+git rev-parse HEAD
+
+sh build/autogen.sh
+
+# Build `libarchive' as slim as possible:
+
+sh configure                     \
+   --disable-dependency-tracking \
+   --disable-shared              \
+   --enable-static               \
+   --disable-bsdtar              \
+   --disable-bsdcat              \
+   --disable-bsdcpio             \
+   --enable-posix-regex-lib=libc \
+   --disable-xattr               \
+   --disable-acl                 \
+   --disable-largefile           \
+   --without-zlib                \
+   --without-bz2lib              \
+   --without-iconv               \
+   --without-libiconv-prefix     \
+   --without-lz4                 \
+   --without-zstd                \
+   --without-lzma                \
+   --with-lzo2                   \
+   --without-cng                 \
+   --without-nettle              \
+   --without-openssl             \
+   --without-xml2                \
+   --without-expat
+
+make -j$(nproc)
+
+cd "${dir}"

--- a/fuzzing/scripts/custom-build.sh
+++ b/fuzzing/scripts/custom-build.sh
@@ -242,8 +242,9 @@ fi
 export LDFLAGS="${ldflags}"
 
 # ----------------------------------------------------------------------------
-# build FreeType:
+# build libarchive + FreeType:
 
+bash build-libarchive.sh
 bash build-freetype.sh
 
 # ----------------------------------------------------------------------------

--- a/fuzzing/scripts/run-travis-ci.sh
+++ b/fuzzing/scripts/run-travis-ci.sh
@@ -25,6 +25,8 @@ export CFLAGS="${CFLAGS} -g -O1 ${sanitize_flags[@]}"
 export CXXFLAGS="${CXXFLAGS} -g -O1 -std=c++14 ${sanitize_flags[@]}"
 export LDFLAGS="${LDFLAGS} ${sanitize_flags[@]}"
 
+bash build-libarchive.sh
+
 bash build-freetype.sh
 
 bash build-targets.sh

--- a/fuzzing/src/driver/CMakeLists.txt
+++ b/fuzzing/src/driver/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(driver
 
 target_link_libraries(driver
   PRIVATE
-  archive
+  "${LIBARCHIVE_STATIC_LIBRARY}"
   fuzztargets
   "${FREETYPE_STATIC_LIBRARY}")
 

--- a/fuzzing/src/fuzzers/CMakeLists.txt
+++ b/fuzzing/src/fuzzers/CMakeLists.txt
@@ -29,14 +29,6 @@ set(libfuzzer_exes
 # libraries of that environment and fall back to dynamic linking if all else
 # fails.
 
-set("link_libarchive" "archive")
-
-set("oss_path_libarchive" "/usr/lib/x86_64-linux-gnu/libarchive.a")
-
-if (EXISTS "${oss_path_libarchive}")
-  set("link_libarchive" "${oss_path_libarchive}")
-endif()
-
 add_executable(libfuzzer-legacy
   "${FUZZING_SRC_DIR}/legacy/ftfuzzer.cc")
 
@@ -54,7 +46,7 @@ foreach(exe ${libfuzzer_exes})
 
   target_link_libraries("libfuzzer-${exe}"
     PRIVATE
-    "${link_libarchive}"
+    "${LIBARCHIVE_STATIC_LIBRARY}"
     "${FREETYPE_STATIC_LIBRARY}")
 
   # `-fsanitize=fuzzer' or `-lFuzzingEngine' cannot be set earlier since CMake


### PR DESCRIPTION
comes bundled with Ubuntu Xenial, the current platform of OSS-Fuzz.
- Add `libarchive 3.3.1' as submodule.
- Integrate `libarchive' into the build logic.
- Link the static version.
- Update .travis.yml