### PR TITLE
Remove the `glog' package from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
         - TRAVIS_CI_ROW="fuzzing"
 
 before_install:
-  - sudo apt-get -qq update && sudo apt-get install -y autoconf cmake libgoogle-glog-dev libtool
+  - sudo apt-get -qq update && sudo apt-get install -y autoconf cmake libtool
   - eval "${MATRIX_EVAL}"
 
 script:


### PR DESCRIPTION
- Logging should always be compiled out from regression tests.