### PR TITLE
Improve the custom build script:

### DIFF
--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -1,5 +1,20 @@
 # CMakeLists.txt
 #
+# This script listens to a few environmental variables:
+#
+#   CMAKE_DRIVER_EXE_NAME
+#     (optional) Override the default name "driver".
+#
+#   CMAKE_FUZZING_ENGINE
+#     If set:  set up everything to build the fuzzers.  The value is expected
+#              to be a linkable library that contains the desired
+#              implementation of the fuzzer.
+#              For example: `-fsanitize=fuzzer'.
+#     If not set:  set up everything to build the driver.
+#
+#   CMAKE_USE_LOGGER_GLOG
+#     (optional) If set and `1', glog will be linked.
+#
 # Copyright 2018 by
 # Armin Hasitzka.
 #
@@ -14,6 +29,11 @@ cmake_minimum_required(VERSION 3.0)
 project(fuzzing)
 
 set(FUZZING_ENGINE "$ENV{CMAKE_FUZZING_ENGINE}")
+
+set(DRIVER_EXE_NAME "driver")
+if(NOT "$ENV{CMAKE_DRIVER_EXE_NAME}" STREQUAL "")
+  set(DRIVER_EXE_NAME "$ENV{CMAKE_DRIVER_EXE_NAME}")
+endif()
 
 if("$ENV{CMAKE_USE_LOGGER_GLOG}")
   set(LOGGER_NAME "LOGGER_GLOG")

--- a/fuzzing/scripts/build-targets.sh
+++ b/fuzzing/scripts/build-targets.sh
@@ -10,11 +10,10 @@ set -euxo pipefail
 # indicate that you have read the license and understand and accept it
 # fully.
 
-dir=$PWD
+dir="${PWD}"
 cd ..
 
-rm -rf build
-mkdir build && cd build
+mkdir -p build && cd build
 
 cmake -DCMAKE_BUILD_TYPE=Debug ..
 make -j$(nproc)

--- a/fuzzing/scripts/custom-build.sh
+++ b/fuzzing/scripts/custom-build.sh
@@ -40,26 +40,46 @@ fi
 ansi_reset="\e[0m"
 ansi_bold="\e[1m"
 ansi_underline="\e[4m"
+ansi_red="\e[31m"
 ansi_yellow="\e[33m"
 
-build_type=
-build_asan=
-build_ubsan=
-build_coverage=
-build_debugging=
-build_ft_trace=
+build_type=      # d|f
+build_asan=      # y|n
+build_ubsan=     # y|n
+build_coverage=  # y|n
+build_debugging= # 0|1|2|3|n
+build_ft_trace=  # y|n
 
-printf "local: [%s], global: [%s]\n" "${build_type}" "${BUILD_TYPE}"
+cflags="${CFLAGS}"
+cxxflags="${CXXFLAGS}"
+ldflags="${LDFLAGS}"
+
+# Base name of the driver:
+driver_name="driver"
 
 # ----------------------------------------------------------------------------
 # helpers:
 
-# print question:
+# Print the new line character (\n).
+function print_nl {
+    printf "\n"
+}
+
+# Print a question.
+#
+# $1: Question string.
 function print_q {
     printf "\n${ansi_bold}%s${ansi_reset}\n" "${1}"
 }
 
-# print info:
+# Print some information.
+#
+# $1: Name of an option.
+# $2: Description of the option.
+#
+# .. or ...
+#
+# $1: General information.
 function print_info {
     if [[ "$#" == "1" ]]; then
         printf "  %s\n" "${1}"
@@ -70,23 +90,46 @@ function print_info {
     fi
 }
 
-# print url:
+# Print a url.
+#
+# $1: URL.
 function print_url {
     printf "  ${ansi_underline}%s${ansi_reset}\n" "${1}"
 }
 
-# print selection
-# param 1: value
-# param 2: cmp value
-# param 3: string
+# Print (+ verify) the selection of an option.
+#
+# $1: The chosen option.
+# ${2n + 2, n >= 0}: The nth option.
+# ${2n + 3, n >= 0}: The nth description of an option.
+#
+# Example: $ print_sel ${selection} "y" "yes" "n" "no" ...
 function print_sel {
-    if [[ "${1}" == "${2}" ]]; then
-        printf "\n  selection: ${ansi_yellow}%s${ansi_reset}\n" "${3}"
-    fi
+    i=2
+    while [[ i -le "$#" ]]; do
+        if [[ "${1}" == "${!i}" ]]; then
+            i=$(( i + 1 ))
+            printf "\n  selection: ${ansi_yellow}%s${ansi_reset}\n" "${!i}"
+            return
+        fi
+        i=$(( i + 2 ))
+    done
+    printf "\n  ${ansi_red}${ansi_bold}invalid selection: %s${ansi_reset}\n\n" "${1}"
+    exit 66
 }
 
-# param 1: a list of options like "a|b|c"
-# param 2 (optional): a default option like "a"
+# Print (+ verify) the slection of an option that can either be "y" (yes) or
+# "n" (no).
+#
+# $1: The chosen option.
+function print_sel_yes_no {
+    print_sel "${1}" "y" "yes" "n" "no"
+}
+
+# Ask the user and print the (accepted + valid) result.
+#
+# $1: a list of options like "a|b|c"
+# $2 (optional): a default option like "a"
 function ask_user {
     options="${1}"
     if [[ "$#" == "2" ]]; then
@@ -100,8 +143,8 @@ function ask_user {
             break
         fi
         if [[ "${1}" == *"|${answer}|"* ||
-                  "${1}" == *"|${answer}" ||
-                  "${1}" == "${answer}|"* ]]; then
+              "${1}" == *"|${answer}"   ||
+              "${1}" ==   "${answer}|"* ]]; then
             echo "${answer}"
             break
         fi
@@ -121,145 +164,157 @@ printf "|_|  |_| \_\____)____) |_| /_/   |_|   |____)\n\n"
 printf "${ansi_reset}"
 printf "               Custom Build\n"
 
-print_q "Build the driver or the fuzzer?"
+print_q    "Build the driver or the fuzzer?"
 print_info "driver" "run selected samples or failed instances"
 print_info "fuzzer" "fuzz a corpus of samples with libFuzzer"
-printf "\n"
-build_type=$(ask_user "d|f")
-print_sel "${build_type}" "d" "driver"
-print_sel "${build_type}" "f" "fuzzer"
+print_nl
 
-print_q "Add the AddressSanitizer?"
+build_type=$( ask_user "d|f" )
+print_sel "${build_type}" "d" "driver" "f" "fuzzer"
+
+if [[ "${build_type}" == "f" ]]; then
+    cflags="  ${cflags}   -fsanitize=fuzzer-no-link"
+    cxxflags="${cxxflags} -fsanitize=fuzzer-no-link"
+
+    export CMAKE_FUZZING_ENGINE="-fsanitize=fuzzer"
+fi
+
+print_q   "Add the AddressSanitizer?"
 print_url "https://clang.llvm.org/docs/AddressSanitizer.html"
-printf "\n"
-build_asan=$(ask_user "y|n" "y")
-print_sel "${build_asan}" "y" "yes"
-print_sel "${build_asan}" "n" "no"
+print_nl
 
-print_q "Add the UndefinedBehaviorSanitizer?"
+build_asan=$( ask_user "y|n" "y" )
+print_sel_yes_no "${build_asan}"
+
+if [[ "${build_asan}" == "y" ]]; then
+    cflags="  ${cflags}   -fsanitize=address -fsanitize-address-use-after-scope"
+    cxxflags="${cxxflags} -fsanitize=address -fsanitize-address-use-after-scope"
+    ldflags=" ${ldflags}  -fsanitize=address"
+
+    driver_name="${driver_name}-asan"
+fi
+
+print_q   "Add the UndefinedBehaviorSanitizer?"
 print_url "https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html"
-printf "\n"
-build_ubsan=$(ask_user "y|n" "y")
-print_sel "${build_ubsan}" "y" "yes"
-print_sel "${build_ubsan}" "n" "no"
+print_nl
 
-print_q "Add coverage instrumentation?"
+build_ubsan=$( ask_user "y|n" "y" )
+print_sel_yes_no "${build_ubsan}"
+
+if [[ "${build_ubsan}" == "y" ]]; then
+    cflags="  ${cflags}   -fsanitize=undefined"
+    cxxflags="${cxxflags} -fsanitize=undefined"
+    ldflags=" ${ldflags}  -fsanitize=undefined"
+
+    driver_name="${driver_name}-ubsan"
+fi
+
+print_q   "Add coverage instrumentation?"
 print_url "https://clang.llvm.org/docs/SourceBasedCodeCoverage.html"
-printf "\n"
-build_coverage=$(ask_user "y|n" "n")
-print_sel "${build_coverage}" "y" "yes"
-print_sel "${build_coverage}" "n" "no"
+print_nl
+
+build_coverage=$( ask_user "y|n" "n" )
+print_sel_yes_no "${build_coverage}"
+
+if [[ "${build_coverage}" == "y" ]]; then
+    cflags="  ${cflags}   -fprofile-instr-generate -fcoverage-mapping"
+    cxxflags="${cxxflags} -fprofile-instr-generate -fcoverage-mapping"
+    ldflags=" ${ldflags}  -fprofile-instr-generate"
+
+    driver_name="${driver_name}-cov"
+fi
 
 if [[ "${build_asan}" == "y" || "${build_ubsan}" == "y" ]]; then
-    build_debugging="1"
+    print_q    "Choose the optimisation level:"
+    print_info "0" "compile with '-g -O0'"
+    print_info "1" "compile with '-g -O1'"
+    print_info "2" "compile with '-g -O2'"
+    print_info "3" "compile with '-g -O3'"
+    print_nl
+
+    build_debugging=$( ask_user "0|1|2|3" "1" )
+    print_sel "${build_debugging}" \
+              "0" "-g -O0"         \
+              "1" "-g -O1"         \
+              "2" "-g -O2"         \
+              "3" "-g -O3"
 else
-    print_q "Add debugging flags?"
+    print_q    "Add debugging flags?"
     print_info "0" "compile with '-g -O0'"
     print_info "1" "compile with '-g -O1'"
     print_info "2" "compile with '-g -O2'"
     print_info "3" "compile with '-g -O3'"
     print_info "n" "compile without debugging flags"
-    printf "\n"
-    build_debugging=$(ask_user "0|1|2|3|n" "1")
-    print_sel "${build_debugging}" "0" "-g O0"
-    print_sel "${build_debugging}" "1" "-g O1"
-    print_sel "${build_debugging}" "2" "-g O2"
-    print_sel "${build_debugging}" "3" "-g O3"
-    print_sel "${build_debugging}" "n" "no"
+    print_nl
+
+    build_debugging=$( ask_user "0|1|2|3|n" "1" )
+    print_sel "${build_debugging}" \
+              "0" "-g -O0"         \
+              "1" "-g -O1"         \
+              "2" "-g -O2"         \
+              "3" "-g -O3"         \
+              "n" "no"
+fi
+
+if [[ "${build_debugging}" != "n" ]]; then
+    cflags="  ${cflags}   -g -O${build_debugging}"
+    cxxflags="${cxxflags} -g -O${build_debugging}"
+
+    driver_name="${driver_name}-o${build_debugging}"
 fi
 
 if [[ "${build_type}" == "f" ]]; then
     build_glog="n"
 else
-    print_q "Use Glog logger?"
-    print_url "https://github.com/google/glog"
+    print_q    "Use Glog logger?"
+    print_url  "https://github.com/google/glog"
     print_info "no" "logging will be compiled out and glog will not be linked"
-    printf "\n"
-    build_glog=$(ask_user "y|n" "n")
-    print_sel "${build_glog}" "y" "yes"
-    print_sel "${build_glog}" "n" "no"
+    print_nl
+
+    build_glog=$( ask_user "y|n" "n" )
+    print_sel_yes_no "${build_glog}"
+fi
+
+if [[ "${build_glog}" == "y" ]]; then
+    export CMAKE_USE_LOGGER_GLOG=1
+
+    driver_name="${driver_name}-glog"
 fi
 
 if [[ "${build_type}" == "f" ]]; then
     build_ft_trace="n"
 else
-    print_q "Add FreeType tracing?"
+    print_q    "Add FreeType tracing?"
     print_info "yes" "activate 'FT_DEBUG_LEVEL_{TRACE,ERROR}'"
-    printf "\n"
+    print_nl
+
     build_ft_trace=$(ask_user "y|n" "n")
-    print_sel "${build_ft_trace}" "y" "yes"
-    print_sel "${build_ft_trace}" "n" "no"
-fi
-
-# ----------------------------------------------------------------------------
-# assemble the flags:
-
-cflags="${CFLAGS}"
-cxxflags="${CXXFLAGS}"
-ldflags="${LDFLAGS}"
-
-if [[ "${build_debugging}" != "n" ]]; then
-    cflags="${cflags} -g -O${build_debugging}"
-    cxxflags="${cxxflags} -g -O${build_debugging}"
-fi
-
-if [[ "${build_asan}" == "y" ]]; then
-    cflags="${cflags} -fsanitize=address -fsanitize-address-use-after-scope"
-    cxxflags="${cxxflags} -fsanitize=address -fsanitize-address-use-after-scope"
-    ldflags="${ldflags} -fsanitize=address"
-fi
-
-if [[ "${build_ubsan}" == "y" ]]; then
-    cflags="${cflags} -fsanitize=undefined"
-    cxxflags="${cxxflags} -fsanitize=undefined"
-    ldflags="${ldflags} -fsanitize=undefined"
-fi
-
-if [[ "${build_coverage}" == "y" ]]; then
-    cflags="${cflags} -fprofile-instr-generate -fcoverage-mapping"
-    cxxflags="${cxxflags} -fprofile-instr-generate -fcoverage-mapping"
-    ldflags="${ldflags} -fprofile-instr-generate"
+    print_sel_yes_no "${build_ft_trace}"
 fi
 
 if [[ "${build_ft_trace}" == "y" ]]; then
-    cflags="${cflags} -DFT_DEBUG_LEVEL_TRACE -DFT_DEBUG_LEVEL_ERROR"
+    cflags="  ${cflags}   -DFT_DEBUG_LEVEL_TRACE -DFT_DEBUG_LEVEL_ERROR"
     cxxflags="${cxxflags} -DFT_DEBUG_LEVEL_TRACE -DFT_DEBUG_LEVEL_ERROR"
+
+    driver_name="${driver_name}-fttrace"
 fi
+
+print_nl
+
+# ----------------------------------------------------------------------------
+# export flags and build everything:
 
 export CC="clang"
 export CXX="clang++"
 
-if [[ "${build_type}" == "d" ]]; then
-    export CFLAGS="${cflags}"
-    export CXXFLAGS="${cxxflags}"
-elif [[ "${build_type}" == "f" ]]; then
-    export CFLAGS="${cflags} -fsanitize=fuzzer-no-link"
-    export CXXFLAGS="${cxxflags} -fsanitize=fuzzer-no-link"
-else
-    exit 66
-fi
-
+export CFLAGS="${cflags}"
+export CXXFLAGS="${cxxflags}"
 export LDFLAGS="${ldflags}"
 
-# ----------------------------------------------------------------------------
-# build libarchive + FreeType:
+export CMAKE_DRIVER_EXE_NAME="${driver_name}"
 
 bash build-libarchive.sh
 bash build-freetype.sh
-
-# ----------------------------------------------------------------------------
-# build the targets:
-
-if [[ "${build_type}" == "f" ]]; then
-    export CMAKE_FUZZING_ENGINE="-fsanitize=fuzzer"
-elif [[ "${build_type}" != "d" ]]; then
-    exit 66
-fi
-
-if [[ "${build_glog}" == "y" ]]; then
-    export CMAKE_USE_LOGGER_GLOG=1
-fi
-
 bash build-targets.sh
 
 cd "${dir}"

--- a/fuzzing/src/driver/CMakeLists.txt
+++ b/fuzzing/src/driver/CMakeLists.txt
@@ -13,6 +13,8 @@ add_executable(driver
   "${FUZZING_SRC_DIR}/driver/driver.cpp"
   "${FUZZING_SRC_DIR}/legacy/ftfuzzer.cc")
 
+set_target_properties(driver PROPERTIES OUTPUT_NAME "${DRIVER_EXE_NAME}")
+
 target_link_libraries(driver
   PRIVATE
   "${LIBARCHIVE_STATIC_LIBRARY}"


### PR DESCRIPTION
- Reformat: align source code much more nicely.
- Restructure: merge collecting + assembling the flags.
- Improve the logic and avoid some duplicated code.
- Customise the name of the driver executable.
- Stop flushing the targets' build folder when building with the build scripts to keep old drivers (until they get overwritten).