### PR TITLE
Cleanup the visitors and iterators

### DIFF
--- a/fuzzing/src/iterators/faceprepiterator-multiplemasters.cpp
+++ b/fuzzing/src/iterators/faceprepiterator-multiplemasters.cpp
@@ -48,9 +48,14 @@
     }
 
     // Select arbitrary coordinates:
-    for ( auto  i = 0; i < master->num_axis; i++ )
+    for ( auto  i = 0;
+          i < master->num_axis &&
+            i < AXIS_INDEX_MAX;
+          i++ )
       coords.push_back( ( master->axis[i].minimum +
                           master->axis[i].def ) / 2 );
+
+    WARN_ABOUT_IGNORED_VALUES( master->num_axis, AXIS_INDEX_MAX, "axis" );
 
     error = FT_Set_Var_Design_Coordinates( face.get(),
                                            coords.size(),

--- a/fuzzing/src/iterators/faceprepiterator-multiplemasters.h
+++ b/fuzzing/src/iterators/faceprepiterator-multiplemasters.h
@@ -58,6 +58,9 @@
   private:
 
 
+    static const FT_UInt  AXIS_INDEX_MAX = 10;
+
+
     Unique_FT_Face
     free_and_return( FT_Library      library,
                      FT_MM_Var*      master,

--- a/fuzzing/src/visitors/facevisitor-charcodes.cpp
+++ b/fuzzing/src/visitors/facevisitor-charcodes.cpp
@@ -67,7 +67,8 @@
     }
 
     for ( FT_Int  charmap_index = 0;
-          charmap_index < face->num_charmaps;
+          charmap_index < face->num_charmaps &&
+            charmap_index < CHARMAP_INDEX_MAX;
           charmap_index++ )
     {
       FT_CharMap charmap = face->charmaps[charmap_index];
@@ -90,6 +91,10 @@
 
       (void) slide_along( face );
     }
+
+    WARN_ABOUT_IGNORED_VALUES( face->charmaps,
+                               CHARMAP_INDEX_MAX,
+                               "character maps" );
   }
 
 

--- a/fuzzing/src/visitors/facevisitor-charcodes.h
+++ b/fuzzing/src/visitors/facevisitor-charcodes.h
@@ -53,8 +53,9 @@
   private:
 
     
-    // The operations are cheap but no need to exaggerate:
-    static const FT_UInt  SLIDE_ALONG_MAX = 50;
+    // These operations are cheap but no need to exaggerate:
+    static const FT_UInt  SLIDE_ALONG_MAX   = 50;
+    static const FT_Int   CHARMAP_INDEX_MAX = 10;
 
     vector<pair<FT_Encoding, string>>  encodings;
 

--- a/fuzzing/src/visitors/facevisitor-gasp.cpp
+++ b/fuzzing/src/visitors/facevisitor-gasp.cpp
@@ -35,6 +35,6 @@
     for ( auto  ppem : ppems )
     {
       flags = FT_Get_Gasp( face.get(), ppem );
-      LOG( INFO ) << "gasp: " << hex << flags;
+      LOG( INFO ) << "gasp: " << hex << "0x" << flags;
     }
   }

--- a/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
+++ b/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
@@ -21,7 +21,7 @@
   FaceVisitorMultipleMasters::
   FaceVisitorMultipleMasters( FaceLoader::FontFormat  format )
   {
-    is_adobe_mm = format == FaceLoader::FontFormat::TYPE_1 ? true : false;
+    has_adobe_mm = format == FaceLoader::FontFormat::TYPE_1 ? true : false;
   }
 
 
@@ -49,7 +49,7 @@
 
     library = face->glyph->library;
 
-    if ( is_adobe_mm == true )
+    if ( has_adobe_mm == true )
     {
       error = FT_Get_Multi_Master( face.get(), &master );
       LOG_IF( ERROR, error != 0 ) << "FT_Get_Multi_Master failed: " << error;
@@ -81,7 +81,10 @@
     }
 
     // Select arbitrary coordinates:
-    for ( auto  i = 0; i < var->num_axis; i++ )
+    for ( auto  i = 0;
+          i < var->num_axis &&
+            i < AXIS_INDEX_MAX;
+          i++ )
     {
       coords_var_design.push_back( ( var->axis[i].minimum +
                                      var->axis[i].def ) / 2 );
@@ -91,6 +94,8 @@
       coords_mm_blend.push_back( 0x10000L * 0.5 );
       coords_var_blend.push_back( 0x10000L * 0.5 );
     }
+
+    WARN_ABOUT_IGNORED_VALUES( var->num_axis, AXIS_INDEX_MAX, "axis" );
 
     (void) test_coords( face,
                         coords_var_design,
@@ -131,7 +136,7 @@
       LOG_IF( ERROR, error != 0 )
         << "FT_Get_Var_Axis_Flags failed: " << error;
       LOG_IF( INFO, error == 0 )
-        << "flags of axis " << ( i + 1 ) << ": " << hex << flags;
+        << "flags of axis " << ( i + 1 ) << ": " << hex << "0x" << flags;
     }
 
     for ( auto  i = 0; i < var->num_namedstyles; i++ )

--- a/fuzzing/src/visitors/facevisitor-multiplemasters.h
+++ b/fuzzing/src/visitors/facevisitor-multiplemasters.h
@@ -71,7 +71,9 @@
   private:
 
 
-    bool  is_adobe_mm;
+    static const FT_UInt  AXIS_INDEX_MAX = 10;
+
+    bool  has_adobe_mm;
 
 
     // @Description:

--- a/fuzzing/src/visitors/facevisitor-sfntnames.cpp
+++ b/fuzzing/src/visitors/facevisitor-sfntnames.cpp
@@ -38,7 +38,8 @@
     num_sfnt_names = FT_Get_Sfnt_Name_Count( face.get() );
 
     for ( FT_UInt  index = 0;
-          index < num_sfnt_names && index < SFNT_NAME_MAX;
+          index < num_sfnt_names &&
+            index < SFNT_NAME_MAX;
           index++ )
     {
       error = FT_Get_Sfnt_Name( face.get(), index, &sfnt_name );

--- a/fuzzing/src/visitors/facevisitor-truetypetables.cpp
+++ b/fuzzing/src/visitors/facevisitor-truetypetables.cpp
@@ -63,7 +63,8 @@
     if ( error == 0 )
     {
       for ( FT_UInt table_index = 0;
-            table_index < num_tables;
+            table_index < num_tables &&
+              table_index < TABLE_INDEX_MAX;
             table_index++ )
       {
         error = FT_Sfnt_Table_Info( face.get(),
@@ -87,6 +88,8 @@
                                     buffer,
                                     &buffer_len );
       }
+
+      WARN_ABOUT_IGNORED_VALUES( num_tables, TABLE_INDEX_MAX, "tables" );
     }
 
     for ( FT_Int  charmap_index = 0;

--- a/fuzzing/src/visitors/facevisitor-truetypetables.h
+++ b/fuzzing/src/visitors/facevisitor-truetypetables.h
@@ -49,6 +49,12 @@
     void
     run( Unique_FT_Face  face )
     override;
+
+
+  private:
+
+
+    static const FT_ULong  TABLE_INDEX_MAX = 20;
   };
 
 

--- a/fuzzing/src/visitors/facevisitor-variants.cpp
+++ b/fuzzing/src/visitors/facevisitor-variants.cpp
@@ -46,8 +46,11 @@
     }
 
     while ( *raw_selectors != 0 )
+    {
       selectors.push_back( *raw_selectors++ );
-
+      if ( selectors.size() >= VARIANT_SELECTORS_MAX )
+        break;
+    }
 
     for ( FT_UInt32  selector : selectors )
     {
@@ -61,8 +64,10 @@
       local_charcodes.clear();
       while ( *raw_chars != 0 )
       {
-        local_charcodes.insert( *raw_chars );
+        local_charcodes.insert(  *raw_chars );
         global_charcodes.insert( *raw_chars++ );
+        if ( local_charcodes.size() >= LOCAL_CHARCODES_MAX )
+          break;
       }
 
       for ( FT_UInt32  charcode : local_charcodes )

--- a/fuzzing/src/visitors/facevisitor-variants.h
+++ b/fuzzing/src/visitors/facevisitor-variants.h
@@ -45,6 +45,13 @@
     void
     run( Unique_FT_Face  face )
     override;
+
+
+  private:
+
+
+    static const size_t  VARIANT_SELECTORS_MAX =  10;
+    static const size_t  LOCAL_CHARCODES_MAX   =  50;
   };
 
 


### PR DESCRIPTION
- Make sure every loop as a reasonable upper bound.
- Values that are printed in `hex` should be prefixed with `0x`.