### PR TITLE
Fuzz `warping` property of the `autofitter` module + small fixes

### DIFF
--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -265,7 +265,7 @@ https://www.freetype.org/freetype2/docs/reference/ft2-properties.html
 | 17.1.3  | `autofitter` | `fallback-script`      |                    |                    |
 | 17.1.4  | `autofitter` | `increase-x-height`    |                    |                    |
 | 17.1.5  | `autofitter` | `no-stem-darkening`    |                    |                    |
-| 17.1.6  | `autofitter` | `warping `             |                    |                    |
+| 17.1.6  | `autofitter` | `warping `             | :heavy_check_mark: | :heavy_check_mark: |
 | 17.1.7  | `cff`        | `darkening-parameters` |                    |                    |
 | 17.1.8  | `cff`        | `hinting-engine`       |                    |                    |
 | 17.1.9  | `cff`        | `no-stem-darkening`    |                    |                    |

--- a/fuzzing/src/targets/CMakeLists.txt
+++ b/fuzzing/src/targets/CMakeLists.txt
@@ -40,8 +40,9 @@ add_library(fuzztargets
   "${FUZZING_SRC_DIR}/utils/tarreader.cpp"
   "${FUZZING_SRC_DIR}/utils/utils.cpp"
 
-  "${FUZZING_SRC_DIR}/visitors/facevisitor-cid.cpp"
+  "${FUZZING_SRC_DIR}/visitors/facevisitor-autohinter.cpp"
   "${FUZZING_SRC_DIR}/visitors/facevisitor-charcodes.cpp"
+  "${FUZZING_SRC_DIR}/visitors/facevisitor-cid.cpp"
   "${FUZZING_SRC_DIR}/visitors/facevisitor-gasp.cpp"
   "${FUZZING_SRC_DIR}/visitors/facevisitor-kerning.cpp"
   "${FUZZING_SRC_DIR}/visitors/facevisitor-loadglyphs.cpp"

--- a/fuzzing/src/targets/font-drivers/cff-render.cpp
+++ b/fuzzing/src/targets/font-drivers/cff-render.cpp
@@ -18,9 +18,9 @@
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "iterators/faceprepiterator-multiplemasters.h"
 #include "iterators/faceprepiterator-outlines.h"
+#include "visitors/facevisitor-autohinter.h"
 #include "visitors/facevisitor-loadglyphs-bitmaps.h"
 #include "visitors/facevisitor-loadglyphs-outlines.h"
-#include "utils/logging.h"
 
 
   using namespace std;
@@ -42,8 +42,14 @@
 
     (void) fpi_bitmaps
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+
+    (void) fpi_outlines
+      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+
+    (void) fpi_mm
+      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_mm
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
 

--- a/fuzzing/src/targets/font-drivers/cidtype1-render.cpp
+++ b/fuzzing/src/targets/font-drivers/cidtype1-render.cpp
@@ -17,6 +17,7 @@
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "iterators/faceprepiterator-outlines.h"
+#include "visitors/facevisitor-autohinter.h"
 #include "visitors/facevisitor-loadglyphs-bitmaps.h"
 #include "visitors/facevisitor-loadglyphs-outlines.h"
 #include "utils/logging.h"
@@ -39,6 +40,9 @@
 
     (void) fpi_bitmaps
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+
+    (void) fpi_outlines
+      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
 

--- a/fuzzing/src/targets/font-drivers/truetype-render.cpp
+++ b/fuzzing/src/targets/font-drivers/truetype-render.cpp
@@ -18,6 +18,7 @@
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "iterators/faceprepiterator-multiplemasters.h"
 #include "iterators/faceprepiterator-outlines.h"
+#include "visitors/facevisitor-autohinter.h"
 #include "visitors/facevisitor-loadglyphs-bitmaps.h"
 #include "visitors/facevisitor-loadglyphs-outlines.h"
 #include "utils/logging.h"
@@ -42,8 +43,14 @@
     
     (void) fpi_bitmaps
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+
+    (void) fpi_outlines
+      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+
+    (void) fpi_mm
+      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_mm
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
 

--- a/fuzzing/src/targets/font-drivers/type1-render-base.cpp
+++ b/fuzzing/src/targets/font-drivers/type1-render-base.cpp
@@ -19,6 +19,7 @@
 #include "iterators/faceprepiterator-multiplemasters.h"
 #include "iterators/faceprepiterator-outlines.h"
 #include "iterators/glyphloaditerator-naive.h"
+#include "visitors/facevisitor-autohinter.h"
 #include "visitors/facevisitor-loadglyphs-bitmaps.h"
 #include "visitors/facevisitor-loadglyphs-outlines.h"
 
@@ -42,8 +43,14 @@
 
     (void) fpi_bitmaps
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+
+    (void) fpi_outlines
+      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+
+    (void) fpi_mm
+      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_mm
       ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
 

--- a/fuzzing/src/visitors/facevisitor-autohinter.cpp
+++ b/fuzzing/src/visitors/facevisitor-autohinter.cpp
@@ -1,0 +1,80 @@
+// facevisitor-autohinter.cpp
+//
+//   Implementation of FaceVisitorAutohinter.
+//
+// Copyright 2018 by
+// Armin Hasitzka.
+//
+// This file is part of the FreeType project, and may only be used,
+// modified, and distributed under the terms of the FreeType project
+// license, LICENSE.TXT.  By continuing to use, modify, or distribute
+// this file you indicate that you have read the license and
+// understand and accept it fully.
+
+
+#include "visitors/facevisitor-autohinter.h"
+
+#include <cassert>
+
+#include <ft2build.h>
+#include FT_MODULE_H 
+
+#include "utils/logging.h"
+
+
+  void
+  FaceVisitorAutohinter::
+  run( Unique_FT_Face  face )
+  {
+    FT_Error  error;
+
+
+    assert( face != nullptr );
+
+    for ( auto  warping : warpings )
+    {
+      LOG( INFO ) << "using warping: " << ( warping == 1 ? "yes" : "no" );
+
+      (void) set_property( face, "warping", &warping );
+      (void) load_glyphs( face );
+    }
+
+    (void) set_property( face, "warping", &default_warping );
+  }
+
+
+  void
+  FaceVisitorAutohinter::
+  set_property( Unique_FT_Face&  face,
+                const string     property_name,
+                const void*      value)
+  {
+    (void) FT_Property_Set( face->glyph->library,
+                            "autofitter",
+                            property_name.c_str(),
+                            value );
+  }
+
+
+  void
+  FaceVisitorAutohinter::
+  load_glyphs( Unique_FT_Face&  face )
+  {
+    FT_Error  error;
+    FT_Long   num_glyphs = face->num_glyphs;
+
+
+    for ( auto  index = 0;
+          index < num_glyphs &&
+            index < GLYPH_INDEX_MAX;
+          index++ )
+    {
+      LOG( INFO ) << "testing glyph " << ( index + 1 ) << "/" << num_glyphs;
+
+      error = FT_Load_Glyph( face.get(), index, load_flags );
+
+      LOG_IF( ERROR, error != 0 ) << "FT_Load_Glyph failed: " << error;
+    }
+
+    WARN_ABOUT_IGNORED_VALUES( num_glyphs, GLYPH_INDEX_MAX, "glyphs" );
+  }

--- a/fuzzing/src/visitors/facevisitor-autohinter.h
+++ b/fuzzing/src/visitors/facevisitor-autohinter.h
@@ -1,0 +1,74 @@
+// facevisitor-autohinter.h
+//
+//   Load glyphs with the autohinter.
+//
+//   Drivers: all
+//
+// Copyright 2018 by
+// Armin Hasitzka.
+//
+// This file is part of the FreeType project, and may only be used,
+// modified, and distributed under the terms of the FreeType project
+// license, LICENSE.TXT.  By continuing to use, modify, or distribute
+// this file you indicate that you have read the license and
+// understand and accept it fully.
+
+
+#ifndef VISITORS_FACE_VISITOR_AUTOHINTER_H_
+#define VISITORS_FACE_VISITOR_AUTOHINTER_H_
+
+
+#include <vector>
+
+#include "utils/utils.h"
+#include "visitors/facevisitor.h"
+
+
+  using namespace std;
+
+
+  class FaceVisitorAutohinter
+  : public FaceVisitor
+  {
+  public:
+
+
+    FaceVisitorAutohinter( void ) {}
+
+
+    FaceVisitorAutohinter( const FaceVisitorAutohinter& ) = delete;
+    FaceVisitorAutohinter& operator= (
+      const FaceVisitorAutohinter& ) = delete;
+
+
+    virtual
+    ~FaceVisitorAutohinter( void ) {}
+
+
+    void
+    run( Unique_FT_Face  face )
+    override;
+
+
+  private:
+
+
+    static const FT_Long  GLYPH_INDEX_MAX = 30;
+
+    FT_Int32  load_flags = FT_LOAD_FORCE_AUTOHINT | FT_LOAD_RENDER;
+
+    FT_Bool          default_warping = 0;
+    vector<FT_Bool>  warpings{ 0, 1 };
+
+
+    void
+    set_property( Unique_FT_Face&  face,
+                  const string     property_name,
+                  const void*      value );
+
+    void
+    load_glyphs( Unique_FT_Face&  face );
+  };
+
+
+#endif // VISITORS_FACE_VISITOR_AUTOHINTER_H_

--- a/fuzzing/src/visitors/facevisitor-charcodes.cpp
+++ b/fuzzing/src/visitors/facevisitor-charcodes.cpp
@@ -46,9 +46,12 @@
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
-
+    FT_Int    num_charmaps;
+    
 
     assert( face != nullptr );
+
+    num_charmaps = face->num_charmaps;
 
     for ( auto  encoding : encodings )
     {
@@ -67,7 +70,7 @@
     }
 
     for ( FT_Int  charmap_index = 0;
-          charmap_index < face->num_charmaps &&
+          charmap_index < num_charmaps &&
             charmap_index < CHARMAP_INDEX_MAX;
           charmap_index++ )
     {
@@ -82,7 +85,7 @@
         continue;
 
       LOG( INFO ) << "load charmap "
-                  << ( charmap_index + 1 ) << "/" << face->num_charmaps;
+                  << ( charmap_index + 1 ) << "/" << num_charmaps;
 
       if ( FT_Get_Charmap_Index( charmap ) != charmap_index )
       {
@@ -92,7 +95,7 @@
       (void) slide_along( face );
     }
 
-    WARN_ABOUT_IGNORED_VALUES( face->charmaps,
+    WARN_ABOUT_IGNORED_VALUES( num_charmaps,
                                CHARMAP_INDEX_MAX,
                                "character maps" );
   }
@@ -107,8 +110,8 @@
     FT_ULong  char_code;
     FT_UInt   glyph_index;
 
-    FT_String   glyph_name[100];
-    FT_UInt     glyph_name_length = 100;
+    FT_String  glyph_name[100];
+    FT_UInt    glyph_name_length = 100;
 
     FT_UInt  slide_index = 0;
 
@@ -136,10 +139,8 @@
       LOG_IF( ERROR, error != 0) << "FT_Load_Char failed: " << error;
 
       if ( FT_HAS_GLYPH_NAMES( face.get() ) != 1 )
-      {
         LOG( INFO ) << "char code: " << char_code << ", "
                     << "glyph index: " << glyph_index;
-      }
       else
       {
         error = FT_Get_Glyph_Name( face.get(),

--- a/fuzzing/src/visitors/facevisitor-loadglyphs.cpp
+++ b/fuzzing/src/visitors/facevisitor-loadglyphs.cpp
@@ -67,11 +67,7 @@
 
           error = FT_Load_Glyph( face.get(), index, load_flags );
 
-          if ( error != 0 )
-          {
-            LOG( ERROR ) << "FT_Load_Glyph failed: " << error;
-            continue; // try the next flag; it might work better.
-          }
+          LOG_IF( ERROR, error != 0 ) << "FT_Load_Glyph failed: " << error;
         }
       }
 


### PR DESCRIPTION
- Add `FaceVisitorAutohinter` to fuzz `warping` of `autofitter`.
- Fix a bug in `FaceVisitorCharCodes`: `WARN_ABOUT_IGNORED_VALUES` failed when compiled with a logger.
- Fix order of includes and CMake lists.