### PR TITLE
Some fixes:

### DIFF
--- a/fuzzing/scripts/build-freetype.sh
+++ b/fuzzing/scripts/build-freetype.sh
@@ -16,7 +16,7 @@ path_to_freetype=$( readlink -f "../../external/freetype2" )
 git submodule init "${path_to_freetype}"
 
 # We always want to run the latest version of FreeType:
-git submodule update --remote "${path_to_freetype}"
+git submodule update --depth 1 --remote "${path_to_freetype}"
 
 cd "${path_to_freetype}"
 

--- a/fuzzing/scripts/build-libarchive.sh
+++ b/fuzzing/scripts/build-libarchive.sh
@@ -13,8 +13,8 @@ set -euxo pipefail
 dir="${PWD}"
 pathToLibarchive=$(readlink -f "../../external/libarchive")
 
-git submodule init   "${pathToLibarchive}"
-git submodule update "${pathToLibarchive}"
+git submodule init             "${pathToLibarchive}"
+git submodule update --depth 1 "${pathToLibarchive}"
 
 cd "${pathToLibarchive}"
 

--- a/fuzzing/src/driver/driver.cpp
+++ b/fuzzing/src/driver/driver.cpp
@@ -68,9 +68,9 @@
                         "  --cidtype1-render\n"                         \
                         "  --truetype\n"                                \
                         "  --truetype-render\n"                         \
-                        "  --type1\n\n"                                 \
-                        "  --type1-render\n\n"                          \
-                        "  --type1-render-tar\n\n"                      \
+                        "  --type1\n"                                   \
+                        "  --type1-render\n"                            \
+                        "  --type1-render-tar\n"                        \
                         "  --type1-tar\n\n"                             \
                         "  --glyphs-outlines\n\n"                       \
                         "File:\n"                                       \


### PR DESCRIPTION
- Only clone the part of `freetype2` and `libarchive` that are necessary.
- Remove unnecessary double linebreaks in the usage message of `driver`.