### PR TITLE
Fix build for `git <= 2.13`

### DIFF
--- a/fuzzing/scripts/build-glog.sh
+++ b/fuzzing/scripts/build-glog.sh
@@ -17,8 +17,14 @@ path_to_build="${path_to_src}/build"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 
-    git submodule init             "${path_to_src}"
-    git submodule update --depth 1 "${path_to_src}"
+    # It's tempting to add `--depth 1' in `git submodule update' but sadly,
+    # `git <= 2.14' does not understand its purpose correctly when working
+    # with tags or commits that are not most recent.  Setting `--depth 1'
+    # conditionally, based on the installed version of `git', is possible and
+    # would save some time when updating submodule.  #goodFirstIssue
+
+    git submodule init   "${path_to_src}"
+    git submodule update "${path_to_src}"
 
     cd "${path_to_src}"
 

--- a/fuzzing/scripts/build-libarchive.sh
+++ b/fuzzing/scripts/build-libarchive.sh
@@ -16,8 +16,14 @@ path_to_src=$( readlink -f "../../external/libarchive" )
 
 if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
 
-    git submodule init             "${path_to_src}"
-    git submodule update --depth 1 "${path_to_src}"
+    # It's tempting to add `--depth 1' in `git submodule update' but sadly,
+    # `git <= 2.14' does not understand its purpose correctly when working
+    # with tags or commits that are not most recent.  Setting `--depth 1'
+    # conditionally, based on the installed version of `git', is possible and
+    # would save some time when updating submodule.  #goodFirstIssue
+
+    git submodule init   "${path_to_src}"
+    git submodule update "${path_to_src}"
 
     cd "${path_to_src}"
 


### PR DESCRIPTION
- Remove `--depth 1' when updating submodules since `git <= 2.14' does not understand its purpose correctly (when working with tags or commits that are not most recent).