### PR TITLE
Fix use of `uninitialised value`:

### DIFF
--- a/fuzzing/src/visitors/facevisitor-type1tables.cpp
+++ b/fuzzing/src/visitors/facevisitor-type1tables.cpp
@@ -104,8 +104,7 @@
 
     (void) get_simple( face, PS_DICT_ENCODING_TYPE,  encoding_type_buffer );
     (void) get_string( face, PS_DICT_ENCODING_ENTRY, string_buffer );
-
-    (void) get_simple( face, PS_DICT_NUM_SUBRS, int_buffer );
+    (void) get_simple( face, PS_DICT_NUM_SUBRS,      int_buffer    );
 
     (void) loop_string( face,
                         num_subrs,

--- a/fuzzing/src/visitors/facevisitor-type1tables.h
+++ b/fuzzing/src/visitors/facevisitor-type1tables.h
@@ -102,10 +102,13 @@
                                    &value,
                                    sizeof( value ) );
 
-      LOG_IF( INFO, size > 0 ) << key << "[" << index << "]: "
-                               << value;
-      LOG_IF( INFO, size <= 0 ) << key << "[" << index << "]: "
-                                << "does not exist";
+      if ( size > 0 )
+        LOG( INFO ) << key << "[" << index << "]: " << value;
+      else
+      {
+        LOG( INFO ) << key << "[" << index << "]: does not exist";
+        value = static_cast<T>( 0 );
+      }
     }
 
 


### PR DESCRIPTION
- `FT_Get_PS_Font_Value` does not touch the value in case of an error.