### PR TITLE
Add a row to Travis CI to build OSS-Fuzz

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,17 +17,21 @@ matrix:
       compiler: clang
       addons:
         apt:
-          sources:
-            - llvm-toolchain-trusty-5.0
-          packages:
-            - clang-5.0
+          sources: llvm-toolchain-trusty-5.0
+          packages: clang-5.0
       env:
+        - TRAVIS_CI_ROW="regression-suite"
         - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
-        - TRAVIS_CI_ROW="fuzzing"
+    - os: linux
+      sudo: required
+      services: docker
+      env:
+        - TRAVIS_CI_ROW="oss-fuzz-build"
+        - MATRIX_EVAL=
 
 before_install:
   - sudo apt-get -qq update && sudo apt-get install -y autoconf cmake libtool
   - eval "${MATRIX_EVAL}"
 
 script:
-  - if [[ "${TRAVIS_CI_ROW}" == "fuzzing" ]]; then bash fuzzing/scripts/run-travis-ci.sh; fi
+  - bash fuzzing/scripts/run-travis-ci.sh

--- a/fuzzing/scripts/README.md
+++ b/fuzzing/scripts/README.md
@@ -13,24 +13,27 @@ The scripts in this folder are designed to build (and prepare) the fuzz
 targets in (and for) various scenarios.  At the moment, there are three main
 stakeholders:
 
-- **OSS-Fuzz**   has two entry points.  First, it calls
-                 [`build-fuzzers.sh`](build-fuzzers.sh).  All environment
-                 variables are set by OSS-Fuzz and in
-                 [OSS-Fuzz's `build.sh`](https://github.com/google/oss-fuzz/blob/master/projects/freetype2/build.sh).
-                 After that, OSS-Fuzz calls
-                 [`prepare-oss-fuzz.sh`](prepare-oss-fuzz.sh), which copies
-                 all files to their designated places and zips up the corpora.
-                 This process is currently split into two parts to allow for
-                 some hacking in
-                 [OSS-Fuzz's `build.sh`](https://github.com/google/oss-fuzz/blob/master/projects/freetype2/build.sh).
+- **OSS-Fuzz** has two entry points.  The process is currently split into two
+  parts to allow for some hacking in [OSS-Fuzz's
+  `build.sh`](https://github.com/google/oss-fuzz/blob/master/projects/freetype2/build.sh).
+    1. First, it calls [`build-fuzzers.sh`](build-fuzzers.sh).  All
+       environment variables are set by OSS-Fuzz and in [OSS-Fuzz's
+       `build.sh`](https://github.com/google/oss-fuzz/blob/master/projects/freetype2/build.sh).
+    2. After that, OSS-Fuzz calls
+       [`prepare-oss-fuzz.sh`](prepare-oss-fuzz.sh), which copies all files to
+       their designated places and zips up the corpora.
+              
+- **Travis CI**  calls [`run-travis-ci.sh`](run-travis-ci.sh), which supports
+  two different rows/lanes:
+    1. [**Regression Suite**](travis-ci/regression-suite.sh):  build a
+       standard version of the [test driver](/fuzzing/src/driver) and run all
+       available regression tests.
+    2. [**OSS-Fuzz Build**](travis-ci/oss-fuzz-build.sh):  build OSS-Fuzz's
+       fuzzers through OSS-Fuzz's infrastructure tools to confirm that the
+       build process works as expected.
 
-- **Travis CI**  calls [`run-travis-ci.sh`](run-travis-ci.sh), which builds a
-                 standard version of the [test driver](/fuzzing/src/driver)
-                 and runs all available tests.
-
-- **Developers** usually want to use [`custom-build.sh`](custom-build.sh). See
-                 [Debugging the Fuzz Targets](#debugging-the-fuzz-targets)
-                 and for details.
+- **Developers** usually want to use [`custom-build.sh`](custom-build.sh).
+  See [Debugging the Fuzz Targets](#debugging-the-fuzz-targets) for details.
 
 # Debugging the Fuzz Targets
 
@@ -91,7 +94,7 @@ FreeType.  Hence, calling `./custom-build.sh` ensures that the test driver is
 built with FreeType's upstream.
 
 When debugging FreeType, it is advisable to make changes to
-`external/freetype2` as these changes will be detected and used by
+`/external/freetype2` as these changes will be detected and used by
 `./custom-build.sh --rebuild`.  **BEWARE**: calling `./custom-build.sh`
 (without `--rebuild`) resets all changes made to that submodule.  Thus, it is
 good practice to save changes in the form of a patch before rebuilding the

--- a/fuzzing/scripts/build-fuzzers.sh
+++ b/fuzzing/scripts/build-fuzzers.sh
@@ -11,7 +11,7 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd "${0%/*}" # go to `fuzzing/scripts'
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts'
 
 # We expect a bunch of flags coming in from the fuzzing framework;  in fact
 # everything that is connected to compilers, sanitizers, coverage, ...  The
@@ -21,8 +21,8 @@ cd "${0%/*}" # go to `fuzzing/scripts'
 # which would cause CMake's setup process to fail.  See
 # `fuzzing/src/fuzzing/CMakeLists.txt' for details.
 
-bash build-libarchive.sh
-bash build-freetype.sh
-bash build-targets.sh
+bash build/libarchive.sh
+bash build/freetype.sh
+bash build/targets.sh
 
 cd "${dir}"

--- a/fuzzing/scripts/build/freetype.sh
+++ b/fuzzing/scripts/build/freetype.sh
@@ -11,8 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
 
-path_to_freetype=$( readlink -f "../../external/freetype2" )
+path_to_freetype=$( readlink -f "../../../external/freetype2" )
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 

--- a/fuzzing/scripts/build/glog.sh
+++ b/fuzzing/scripts/build/glog.sh
@@ -11,8 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
 
-path_to_src=$( readlink -f "../../external/glog" )
+path_to_src=$( readlink -f "../../../external/glog" )
 path_to_build="${path_to_src}/build"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then

--- a/fuzzing/scripts/build/libarchive.sh
+++ b/fuzzing/scripts/build/libarchive.sh
@@ -11,8 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
 
-path_to_src=$( readlink -f "../../external/libarchive" )
+path_to_src=$( readlink -f "../../../external/libarchive" )
 
 if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
 

--- a/fuzzing/scripts/build/targets.sh
+++ b/fuzzing/scripts/build/targets.sh
@@ -11,8 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
 
-path_to_build=$( readlink -f "../build" )
+path_to_build=$( readlink -f "../../build" )
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 

--- a/fuzzing/scripts/custom-build.sh
+++ b/fuzzing/scripts/custom-build.sh
@@ -11,7 +11,7 @@ set -eo pipefail
 # fully.
 
 dir="${PWD}"
-cd "${0%/*}" # go to `fuzzing/scripts'
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts'
 
 # ----------------------------------------------------------------------------
 # collect parameters:
@@ -68,10 +68,10 @@ fi
 # rebuild shortcut:
 
 if [[ "${opt_rebuild}" == "1" ]]; then
-    bash build-glog.sh       --no-init
-    bash build-libarchive.sh --no-init
-    bash build-freetype.sh   --no-init
-    bash build-targets.sh    --no-init
+    bash build/glog.sh       --no-init
+    bash build/libarchive.sh --no-init
+    bash build/freetype.sh   --no-init
+    bash build/targets.sh    --no-init
     exit
 fi
 
@@ -365,8 +365,8 @@ if [[ "${build_glog}" == "y" ]]; then
     bash build-glog.sh
 fi
 
-bash build-libarchive.sh
-bash build-freetype.sh
-bash build-targets.sh
+bash build/libarchive.sh
+bash build/freetype.sh
+bash build/targets.sh
 
 cd "${dir}"

--- a/fuzzing/scripts/prepare-oss-fuzz.sh
+++ b/fuzzing/scripts/prepare-oss-fuzz.sh
@@ -11,7 +11,7 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd "${0%/*}" # go to `fuzzing/scripts'
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts'
 
 bin_base_dir=$(      readlink -f "../build/bin"          )
 corpora_base_dir=$(  readlink -f "../corpora"            )

--- a/fuzzing/scripts/travis-ci/oss-fuzz-build.sh
+++ b/fuzzing/scripts/travis-ci/oss-fuzz-build.sh
@@ -11,19 +11,18 @@ set -exo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts'
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/travis-ci'
 
-case "${TRAVIS_CI_ROW}" in
-    "regression-suite")
-        bash travis-ci/regression-suite.sh
-        ;;
-    "oss-fuzz-build")
-        bash travis-ci/oss-fuzz-build.sh
-        ;;
-    *)
-        printf "\$TRAVIS_CI_ROW has invalid value: '%s'\n" "${TRAVIS_CI_ROW}"
-        exit 66
-        ;;
-esac
+if [[ ! -v "TRAVIS_BUILD_DIR" ]]; then
+    exit 66
+fi
+
+cd "${TRAVIS_BUILD_DIR}"
+
+git clone "https://github.com/google/oss-fuzz.git"
+cd "oss-fuzz"
+
+python infra/helper.py build_image   --pull freetype2
+python infra/helper.py build_fuzzers        freetype2
 
 cd "${dir}"

--- a/fuzzing/scripts/travis-ci/regression-suite.sh
+++ b/fuzzing/scripts/travis-ci/regression-suite.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -exo pipefail
+
+# Copyright 2018 by
+# Armin Hasitzka.
+#
+# This file is part of the FreeType project, and may only be used, modified,
+# and distributed under the terms of the FreeType project license,
+# LICENSE.TXT.  By continuing to use, modify, or distribute this file you
+# indicate that you have read the license and understand and accept it
+# fully.
+
+dir="${PWD}"
+cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/travis-ci'
+
+sanitize_flags=(
+    "-fsanitize=address,undefined"
+    "-fsanitize-address-use-after-scope"
+)
+
+export CC="clang"
+export CXX="clang++"
+
+export CFLAGS="  ${CFLAGS}   -g -O1            ${sanitize_flags[@]}"
+export CXXFLAGS="${CXXFLAGS} -g -O1 -std=c++11 ${sanitize_flags[@]}"
+export LDFLAGS=" ${LDFLAGS}                    ${sanitize_flags[@]}"
+
+cd ..
+
+bash build/libarchive.sh
+bash build/freetype.sh
+bash build/targets.sh
+
+cd ../build
+
+CTEST_OUTPUT_ON_FAILURE=1 make test -j$(nproc)
+
+cd "${dir}"


### PR DESCRIPTION
- Add the OSS-Fuzz row to Travis CI.
- New logic for accessing the scripts' directories.
- Restructure the `/fuzzing/scripts` folder.