### PR TITLE
Use git protocol for checking out FreeType:

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "freetype2"]
   path = external/freetype2
-  url = http://git.sv.nongnu.org/r/freetype/freetype2.git
+  url = git://git.savannah.nongnu.org/freetype/freetype2.git
   branch = master
 [submodule "glog"]
   path = external/glog

--- a/fuzzing/scripts/custom-build.sh
+++ b/fuzzing/scripts/custom-build.sh
@@ -362,7 +362,7 @@ export LDFLAGS="${ldflags}"
 export CMAKE_DRIVER_EXE_NAME="${driver_name}"
 
 if [[ "${build_glog}" == "y" ]]; then
-    bash build-glog.sh
+    bash build/glog.sh
 fi
 
 bash build/libarchive.sh


### PR DESCRIPTION
- Due to an attack of Savannah.
- Fix a path in `custom-build.sh' on the fly.