### PR TITLE
Use `LOG_FT_ERROR` to log all FreeType errors properly.

### DIFF
--- a/fuzzing/src/iterators/faceloaditerator.cpp
+++ b/fuzzing/src/iterators/faceloaditerator.cpp
@@ -92,20 +92,20 @@
 
     const char*  face_name;
 
-    FT_Long  num_faces = face_loader->get_num_faces();
-    FT_Long  face_index = 0;
-
-    FT_Long  num_instances = 0;
-    FT_Long  instance_index = 0;
+    FT_Long  num_faces;
+    FT_Long  num_instances;
 
     
-    for ( face_index = 0;
+    assert( face_loader != nullptr );
+
+    num_faces = face_loader->get_num_faces();
+
+    for ( auto  face_index = 0;
           face_index < num_faces &&
             face_index < FACE_INDEX_MAX;
           face_index++ )
     {
       (void) face_loader->set_face_index( face_index );
-      num_instances = face_loader->get_num_instances();
 
       if ( face_loader->load() == nullptr )
       {
@@ -122,7 +122,9 @@
           visitor->run( face_loader->load() );
       }
 
-      for ( instance_index = 0;
+      num_instances = face_loader->get_num_instances();
+
+      for ( auto  instance_index = 0;
             instance_index < num_instances &&
               instance_index < INSTANCE_INDEX_MAX;
             instance_index++ )

--- a/fuzzing/src/iterators/faceprepiterator-multiplemasters.cpp
+++ b/fuzzing/src/iterators/faceprepiterator-multiplemasters.cpp
@@ -41,11 +41,10 @@
     library = face->glyph->library;
 
     error = FT_Get_MM_Var( face.get(), &master );
+    LOG_FT_ERROR( "FT_Get_MM_Var", error );
+
     if ( error != 0 )
-    {
-      LOG( ERROR ) << "FT_Get_MM_Var failed: " << error;
       return free_and_return( library, master, make_unique_face() );
-    }
 
     // Select arbitrary coordinates:
     for ( auto  i = 0;
@@ -60,11 +59,10 @@
     error = FT_Set_Var_Design_Coordinates( face.get(),
                                            coords.size(),
                                            coords.data() );
+    LOG_FT_ERROR( "FT_Set_Var_Design_Coordinates", error );
+
     if ( error != 0 )
-    {
-      LOG( ERROR) << "FT_Set_Var_Design_Coordinates failed: " << error;
       return free_and_return( library, master, make_unique_face() );
-    }
 
     return free_and_return( library, master, move( face ) );
   }

--- a/fuzzing/src/iterators/faceprepiterator-outlines.cpp
+++ b/fuzzing/src/iterators/faceprepiterator-outlines.cpp
@@ -76,26 +76,19 @@
     error = FT_Set_Pixel_Sizes( face.get(),
                                 get<0>( char_sizes[index] ),
                                 get<1>( char_sizes[index] ) );
+    LOG_FT_ERROR( "FT_Set_Pixel_Sizes", error );
 
     if ( error != 0 )
-    {
-      LOG( ERROR ) << "FT_Set_Pixel_Sizes failed: " << error;
       return make_unique_face();
-    }
 
     error = FT_Set_Char_Size( face.get(),
                               get<2>( char_sizes[index] ),
                               get<3>( char_sizes[index] ),
                               get<4>( char_sizes[index] ),
                               get<5>( char_sizes[index] ) );
+    LOG_FT_ERROR( "FT_Set_Char_Size", error );
 
-    if ( error != 0 )
-    {
-      LOG( ERROR ) << "FT_Set_Char_Size failed: " << error;
-      return make_unique_face();
-    }
-
-    return move( face );
+    return error == 0 ? move( face ) : make_unique_face();
   }
 
 

--- a/fuzzing/src/iterators/glyphloaditerator-naive.cpp
+++ b/fuzzing/src/iterators/glyphloaditerator-naive.cpp
@@ -46,7 +46,7 @@
       LOG( INFO ) << "using glyph " << ( index + 1 ) << "/" << num_glyphs;
 
       error = FT_Load_Glyph( face.get(), index, load_flags );
-      LOG_IF( ERROR, error != 0 ) << "FT_Load_Glyph failed: " << error;
+      LOG_FT_ERROR( "FT_Load_Glyph", error );
 
       if ( error != 0 )
         continue; // try the next glyph; it might work better.

--- a/fuzzing/src/iterators/glyphrenderiterator-allmodes.cpp
+++ b/fuzzing/src/iterators/glyphrenderiterator-allmodes.cpp
@@ -41,11 +41,10 @@
     for ( auto  mode = 0; mode < FT_RENDER_MODE_MAX; mode++ )
     {
       error = FT_Glyph_Copy( glyph.get(), &raw_rendered_glyph );
+      LOG_FT_ERROR( "FT_Glyph_Copy", error );
+
       if ( error != 0 )
-      {
-        LOG( ERROR ) << "FT_Glyph_Copy failed: " << error;
         break; // we can expect this to fail again; bail out!
-      }
 
       LOG( INFO ) << "render mode: " << mode;
 
@@ -53,16 +52,14 @@
                                   static_cast<FT_Render_Mode>( mode ),
                                   0,
                                   1 );
+      LOG_FT_ERROR( "FT_Glyph_To_Bitmap", error );
 
       // Wrap the glyph in a unqiue_ptr asap to reliably invoke the
       // destructor.
       rendered_glyph = make_unique_glyph( raw_rendered_glyph );
 
       if ( error != 0 )
-      {
-        LOG( ERROR ) << "FT_Glyph_To_Bitmap failed: " << error;
         continue;
-      }
 
       for ( auto&  visitor : glyph_visitors )
       {

--- a/fuzzing/src/targets/base.cpp
+++ b/fuzzing/src/targets/base.cpp
@@ -39,11 +39,10 @@
 
     
     error = FT_Init_FreeType( &library );
+    LOG_FT_ERROR( "FT_Init_FreeType", error );
+
     if ( error != 0 )
-    {
-      LOG( ERROR ) << "FT_Init_FreeType failed: " << error;
       return;
-    }
 
     (void) FT_Library_Version( library, &major, &minor, &patch );
     LOG( INFO ) << "using FreeType " << major << "." << minor << "." << patch;
@@ -109,7 +108,7 @@
                              property_name.c_str(),
                              value );
 
-    LOG_IF( ERROR, error != 0 ) << "FT_Property_Set failed: " << error;
+    LOG_FT_ERROR( "FT_Property_Set", error );
 
     return error == 0 ? true : false;
   }

--- a/fuzzing/src/utils/faceloader.cpp
+++ b/fuzzing/src/utils/faceloader.cpp
@@ -184,11 +184,10 @@
                                 face_index,
                                 &face );
 
+    LOG_FT_ERROR( "FT_New_Memory_Face", error );
+
     if ( error != 0 )
-    {
-      LOG( ERROR ) << "FT_New_Memory_face failed: " << error;
       return make_unique_face();
-    }
 
     // If we have more than a single input file coming from an archive,
     // attach them (starting with the second file) using the order given
@@ -207,9 +206,10 @@
 
 
       error = FT_Attach_Stream( face, &open_args );
+      LOG_FT_ERROR( "FT_Attach_Stream", error );
+
       if ( error != 0 )
       {
-        LOG( ERROR ) << "FT_Attach_Stream failed: " << error;
         (void) FT_Done_Face( face );
         return make_unique_face();
       }

--- a/fuzzing/src/utils/logging.h
+++ b/fuzzing/src/utils/logging.h
@@ -16,6 +16,11 @@
 #define UTILS_LOGGING_H_
 
 
+#include <iomanip>
+
+#include <ft2build.h>
+#include FT_ERRORS_H
+
 #ifdef LOGGER_GLOG
 
 #include <glog/logging.h>
@@ -31,6 +36,12 @@
 #define LOG_IF( a, b ) ; if ( 0 ) std::cout
 
 #endif // LOGGER_GLOG
+
+#define LOG_FT_ERROR( fn_name, error )                    \
+  LOG_IF( ERROR, error != 0 )                             \
+  << fn_name << " failed: "                               \
+  << "0x" << setfill( '0' ) << setw( 2 ) << hex << error  \
+  << " (" << FT_Error_String( error ) << ")"
 
 
 #endif // UTILS_LOGGING_H_

--- a/fuzzing/src/utils/utils.cpp
+++ b/fuzzing/src/utils/utils.cpp
@@ -52,7 +52,7 @@
 
 
     error = FT_Glyph_Copy( glyph.get(), &raw_glyph );
-    LOG_IF( ERROR, error != 0 ) << "FT_Glyph_Copy failed: " << error;
+    LOG_FT_ERROR( "FT_Glyph_Copy", error );
 
     return make_unique_glyph( error == 0 ? raw_glyph : nullptr );
   }
@@ -67,7 +67,7 @@
 
 
     error = FT_Get_Glyph( face->glyph, &glyph );
-    LOG_IF( ERROR, error != 0 ) << "FT_Get_Glyph failed: " << error;
+    LOG_FT_ERROR( "FT_Get_Glyph", error );
 
     return make_unique_glyph( error == 0 ? glyph : nullptr );
   }

--- a/fuzzing/src/visitors/facevisitor-autohinter.cpp
+++ b/fuzzing/src/visitors/facevisitor-autohinter.cpp
@@ -72,8 +72,7 @@
       LOG( INFO ) << "testing glyph " << ( index + 1 ) << "/" << num_glyphs;
 
       error = FT_Load_Glyph( face.get(), index, LOAD_FLAGS );
-
-      LOG_IF( ERROR, error != 0 ) << "FT_Load_Glyph failed: " << error;
+      LOG_FT_ERROR( "FT_Load_Glyph", error );
     }
 
     WARN_ABOUT_IGNORED_VALUES( num_glyphs, GLYPH_INDEX_MAX, "glyphs" );

--- a/fuzzing/src/visitors/facevisitor-bdf.cpp
+++ b/fuzzing/src/visitors/facevisitor-bdf.cpp
@@ -45,12 +45,12 @@
       error = FT_Get_BDF_Charset_ID( face.get(),
                                      &charset_encoding,
                                      &charset_registry );
+      LOG_FT_ERROR( "FT_Get_BDF_Charset_ID", error );
 
-      LOG_IF( ERROR, error != 0 )
-        << "FT_Get_BDF_Charset_ID failed: " << error;
-      LOG_IF( INFO, error == 0 )
-        << "BDF charset encoding: " << string( charset_encoding );
-      LOG_IF( INFO, error == 0 )
-        << "BDF charset registry: " << string( charset_registry );
+      if ( error == 0 )
+      {
+        LOG( INFO ) << "BDF charset encoding: " << string( charset_encoding );
+        LOG( INFO ) << "BDF charset registry: " << string( charset_registry );
+      }
     }
   }

--- a/fuzzing/src/visitors/facevisitor-charcodes.cpp
+++ b/fuzzing/src/visitors/facevisitor-charcodes.cpp
@@ -78,8 +78,7 @@
 
 
       error = FT_Set_Charmap ( face.get(), charmap );
-
-      LOG_IF( ERROR, error != 0 ) << "FT_Set_Charmap failed: " << error;
+      LOG_FT_ERROR( "FT_Set_Charmap", error );
 
       if ( error != 0 )
         continue;
@@ -88,9 +87,7 @@
                   << ( charmap_index + 1 ) << "/" << num_charmaps;
 
       if ( FT_Get_Charmap_Index( charmap ) != charmap_index )
-      {
         LOG( ERROR ) << "FT_Get_Charmap_Index failed";
-      }
 
       (void) slide_along( face );
     }
@@ -136,7 +133,7 @@
       // `FT_Load_Char' a few times.
 
       error = FT_Load_Char( face.get(), char_code, FT_LOAD_DEFAULT );
-      LOG_IF( ERROR, error != 0) << "FT_Load_Char failed: " << error;
+      LOG_FT_ERROR( "FT_Load_Char", error );
 
       if ( FT_HAS_GLYPH_NAMES( face.get() ) != 1 )
         LOG( INFO ) << "char code: " << char_code << ", "
@@ -147,8 +144,7 @@
                                    glyph_index,
                                    (void*) glyph_name,
                                    glyph_name_length );
-
-        LOG_IF( ERROR, error != 0 ) << "FT_Get_Glyph_Name failed: " << error;
+        LOG_FT_ERROR( "FT_Get_Glyph_Name", error );
 
         if ( error != 0 )
           continue;

--- a/fuzzing/src/visitors/facevisitor-cid.cpp
+++ b/fuzzing/src/visitors/facevisitor-cid.cpp
@@ -47,9 +47,7 @@
                                                      &registry,
                                                      &ordering,
                                                      &supplement );
-
-    LOG_IF( ERROR, error != 0 ) <<
-      "FT_Get_CID_Registry_Ordering_Supplement failed: " << error;
+    LOG_FT_ERROR( "FT_Get_CID_Registry_Ordering_Supplement", error );
 
     LOG_IF( INFO, error == 0 ) << "cid r/o/s: "
                                << registry << "/"
@@ -57,9 +55,7 @@
                                << supplement;
 
     error = FT_Get_CID_Is_Internally_CID_Keyed( face.get(), &is_cid );
-    
-    LOG_IF( ERROR, error != 0 ) <<
-      "FT_Get_CID_Is_Internally_CID_Keyed failed: " << error;
+    LOG_FT_ERROR( "FT_Get_CID_Is_Internally_CID_Keyed", error );
 
     LOG_IF( INFO, error == 0 ) << "cid is "
                                << ( is_cid == 0 ? "not " : "" )
@@ -71,12 +67,10 @@
           index++ )
     {
       error = FT_Get_CID_From_Glyph_Index( face.get(), index, &cid );
+      LOG_FT_ERROR( "FT_Get_CID_From_Glyph_Index", error );
 
       if ( error != 0)
-      {
-        LOG( ERROR ) << "FT_Get_CID_From_Glyph_Index failed: " << error;
         break; // we can expect this call to fail again.
-      }
 
       LOG_IF( INFO, error == 0 ) << index << "/" << num_glyphs
                                  << " (glyph index) <-> "

--- a/fuzzing/src/visitors/facevisitor-kerning.cpp
+++ b/fuzzing/src/visitors/facevisitor-kerning.cpp
@@ -59,16 +59,14 @@
                                   right_glyph,
                                   kern_mode,
                                   &kerning );
-
-          LOG_IF( ERROR, error != 0) << "FT_Get_Kerning failed: " << error;
+          LOG_FT_ERROR( "FT_Get_Kerning", error );
 
           error = FT_Get_Kerning( face.get(),
                                   right_glyph,
                                   left_glyph,
                                   kern_mode,
                                   &kerning );
-
-          LOG_IF( ERROR, error != 0) << "FT_Get_Kerning failed: " << error;
+          LOG_FT_ERROR( "FT_Get_Kerning", error );
         }
       }
     }

--- a/fuzzing/src/visitors/facevisitor-loadglyphs.cpp
+++ b/fuzzing/src/visitors/facevisitor-loadglyphs.cpp
@@ -73,8 +73,7 @@
           LOG( INFO ) << "load flags: 0x" << hex << flags;
 
           error = FT_Load_Glyph( face.get(), index, flags );
-
-          LOG_IF( ERROR, error != 0 ) << "FT_Load_Glyph failed: " << error;
+          LOG_FT_ERROR( "FT_Load_Glyph", error );
         }
       }
 

--- a/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
+++ b/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
@@ -52,30 +52,28 @@
     if ( has_adobe_mm == true )
     {
       error = FT_Get_Multi_Master( face.get(), &master );
-      LOG_IF( ERROR, error != 0 ) << "FT_Get_Multi_Master failed: " << error;
+      LOG_FT_ERROR( "FT_Get_Multi_Master", error );
 
       if ( error == 0 )
       {
         for ( auto i = 0; i < master.num_axis; i++ )
-        {
           coords_mm_design.push_back( ( master.axis[i].minimum +
                                         master.axis[i].maximum ) / 2 );
-        }
 
         LOG( INFO ) << "testing FT_Set_MM_Design_Coordinates";
 
         error = FT_Set_MM_Design_Coordinates( face.get(),
                                               coords_mm_design.size(),
                                               coords_mm_design.data() );
-        LOG_IF( ERROR, error != 0 )
-          << "FT_Set_MM_Design_Coordinates failed: " << error;
+        LOG_FT_ERROR( "FT_Set_MM_Design_Coordinates", error );
       }
     }
 
     error = FT_Get_MM_Var( face.get(), &var );
+    LOG_FT_ERROR( "FT_Get_MM_Var", error );
+
     if ( error != 0 )
     {
-      LOG( ERROR ) << "FT_Get_MM_Var failed: " << error;
       (void) FT_Done_MM_Var( library, var );
       return;
     }
@@ -133,8 +131,8 @@
 
 
       error = FT_Get_Var_Axis_Flags( var, i, &flags );
-      LOG_IF( ERROR, error != 0 )
-        << "FT_Get_Var_Axis_Flags failed: " << error;
+      LOG_FT_ERROR( "FT_Get_Var_Axis_Flags", error );
+
       LOG_IF( INFO, error == 0 )
         << "flags of axis " << ( i + 1 ) << ": " << hex << "0x" << flags;
     }
@@ -143,9 +141,9 @@
     {
       // TODO: extract the name (strid + psid).
       LOG( INFO ) << "setting named instance " << ( i + 1 );
+
       error = FT_Set_Named_Instance( face.get(), i );
-      LOG_IF( ERROR, error != 0 )
-        << "FT_Set_Named_Instance failed: " << error;
+      LOG_FT_ERROR( "FT_Set_Named_Instance", error );
     }
     
     (void) FT_Done_MM_Var( library, var );
@@ -165,6 +163,5 @@
     LOG( INFO ) << "testing " << fn_name;
 
     error = fn( face.get(), coords.size(), coords.data() );
-
-    LOG_IF( ERROR, error != 0 ) << fn_name << " failed: " << error;
+    LOG_FT_ERROR( fn_name, error );
   }

--- a/fuzzing/src/visitors/facevisitor-renderglyphs.cpp
+++ b/fuzzing/src/visitors/facevisitor-renderglyphs.cpp
@@ -55,12 +55,10 @@
         LOG( INFO ) << "load flags: 0x" << hex << mode.first;
 
         error = FT_Load_Glyph( face.get(), index, mode.first );
+        LOG_FT_ERROR( "FT_Load_Glyph", error );
 
         if ( error != 0 )
-        {
-          LOG( ERROR ) << "FT_Load_Glyph failed: " << error;
           continue;
-        }
 
         if ( glyph_has_reasonable_render_size(
                get_unique_glyph_from_face( face ) ) == false )
@@ -69,8 +67,7 @@
         LOG( INFO ) << "render mode: " << mode.second;
 
         error = FT_Render_Glyph( face->glyph, mode.second );
-
-        LOG_IF( ERROR, error != 0 ) << "FT_Render_Glyph failed: " << error;
+        LOG_FT_ERROR( "FT_Render_Glyph", error );
       }
     }
 

--- a/fuzzing/src/visitors/facevisitor-sfntnames.cpp
+++ b/fuzzing/src/visitors/facevisitor-sfntnames.cpp
@@ -43,10 +43,10 @@
           index++ )
     {
       error = FT_Get_Sfnt_Name( face.get(), index, &sfnt_name );
+      LOG_FT_ERROR( "FT_Get_Sfnt_Name", error );
 
       if ( error != 0 )
       {
-        LOG( ERROR ) << "FT_Get_Sfnt_Name failed: " << error;
         continue;
       }
 
@@ -70,8 +70,8 @@
       error = FT_Get_Sfnt_LangTag( face.get(),
                                    sfnt_name.language_id,
                                    &sfnt_lang );
+      LOG_FT_ERROR( "FT_Get_Sfnt_LangTag", error );
 
-      LOG_IF( ERROR, error != 0 ) << "FT_Get_Sfnt_LangTag failed: " << error;
       LOG_IF( INFO, error == 0 )
         << "sfnt lang tag "
         << ( index + 1 ) << "/" << num_sfnt_names << ": "

--- a/fuzzing/src/visitors/facevisitor-subglyphs.cpp
+++ b/fuzzing/src/visitors/facevisitor-subglyphs.cpp
@@ -47,12 +47,10 @@
       LOG( INFO ) << "testing glyph " << ( index + 1 ) << "/" << num_glyphs;
 
       error = FT_Load_Glyph( face.get(), index, LOAD_FLAGS );
+      LOG_FT_ERROR( "FT_Load_Glyph", error );
 
       if ( error != 0 )
-      {
-        LOG( ERROR ) << "FT_Load_Glyph failed: " << error;
         continue;
-      }
 
       if ( face->glyph->format != FT_GLYPH_FORMAT_COMPOSITE )
       {
@@ -74,9 +72,8 @@
                                       &sg_arg1,
                                       &sg_arg2,
                                       &sg_transform );
+        LOG_FT_ERROR( "FT_Get_SubGlyph_Info", error );
 
-        LOG_IF( ERROR, error != 0 )
-                        << "FT_Get_SubGlyph_Info failed: " << error;
         LOG_IF( INFO, error == 0 )
           << "subglyph " << ( sub_index + 1 ) << "/" << num_subglyphs << ": "
           << "glyph #" << sg_index << ", "

--- a/fuzzing/src/visitors/facevisitor-trackkerning.cpp
+++ b/fuzzing/src/visitors/facevisitor-trackkerning.cpp
@@ -44,7 +44,6 @@
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
-
     FT_Fixed  kerning;
 
 
@@ -61,9 +60,8 @@
                                       point_size,
                                       degree,
                                       &kerning );
+        LOG_FT_ERROR( "FT_Get_Track_Kerning", error );
 
-        LOG_IF( ERROR, error != 0 )
-          << "FT_Get_Track_Kerning failed: " << error;
         LOG_IF( INFO, error == 0)
           << "track kerning of "
           << point_size << "/" << degree << ": " << kerning;

--- a/fuzzing/src/visitors/facevisitor-truetypetables.cpp
+++ b/fuzzing/src/visitors/facevisitor-truetypetables.cpp
@@ -53,12 +53,10 @@
     LOG( INFO ) << "load whole font file";
 
     error = FT_Load_Sfnt_Table( face.get(), 0, 0, buffer, &buffer_len );
-
-    LOG_IF( ERROR, error != 0 ) << "FT_Load_Sfnt_Table failed: " << error;
+    LOG_FT_ERROR( "FT_Load_Sfnt_Table", error );
 
     error = FT_Sfnt_Table_Info ( face.get(), 0, nullptr, &num_tables );
-
-    LOG_IF( ERROR, error != 0 ) << "FT_Sfnt_Table_Info failed: " << error;
+    LOG_FT_ERROR( "FT_Sfnt_Table_Info", error );
 
     if ( error == 0 )
     {
@@ -71,9 +69,7 @@
                                     table_index,
                                     &table_tag,
                                     &table_length );
-
-        LOG_IF( ERROR, error != 0 )
-          << "FT_Sfnt_Table_Info failed: " << error;
+        LOG_FT_ERROR( "FT_Sfnt_Table_Info", error );
 
         if ( error != 0 )
           continue;
@@ -96,7 +92,8 @@
           charmap_index < face->num_charmaps;
           charmap_index++ )
     {
-      FT_CharMap map = face->charmaps[charmap_index];
+      FT_CharMap  map = face->charmaps[charmap_index];
+
       
       cmap_language_id = FT_Get_CMap_Language_ID( map );
       cmap_format      = FT_Get_CMap_Format( map );

--- a/fuzzing/src/visitors/facevisitor-type1tables.cpp
+++ b/fuzzing/src/visitors/facevisitor-type1tables.cpp
@@ -68,7 +68,7 @@
     else if ( error == FT_Err_Invalid_Argument )
       LOG( INFO ) << "face is not postscript based";
     else
-      LOG( ERROR ) << "FT_Get_PS_Font_Info failed: " << error;
+      LOG_FT_ERROR( "FT_Get_PS_Font_Info", error );
 
     error = FT_Get_PS_Font_Private( face.get(), &private_dict );
     
@@ -77,7 +77,7 @@
     else if ( error == FT_Err_Invalid_Argument )
       LOG( INFO ) << "face is not postscript based";
     else
-      LOG( ERROR ) << "FT_Get_PS_Font_Private failed: " << error;
+      LOG_FT_ERROR( "FT_Get_PS_Font_Private", error );
 
     (void) get_simple( face, PS_DICT_FONT_TYPE,   byte_buffer   );
     (void) get_simple( face, PS_DICT_FONT_MATRIX, fixed_buffer  );

--- a/fuzzing/src/visitors/facevisitor-windowsfnt.cpp
+++ b/fuzzing/src/visitors/facevisitor-windowsfnt.cpp
@@ -33,7 +33,7 @@
     assert( face != nullptr );
 
     error = FT_Get_WinFNT_Header( face.get(), &header );
-    
-    LOG_IF( ERROR, error != 0 ) << "FT_Get_WinFNT_Header failed: " << error;
+    LOG_FT_ERROR( "FT_Get_WinFNT_Header", error );
+
     LOG_IF( INFO, error == 0) << "retrieved Windows FNT font info header";
   }

--- a/fuzzing/src/visitors/glyphvisitor-bitmap-handling.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-bitmap-handling.cpp
@@ -109,7 +109,7 @@
 
 
     error = FT_Bitmap_Copy( library, &source, &target );
-    LOG_IF( ERROR, error != 0 ) << "FT_Bitmap_Copy failed: " << error;
+    LOG_FT_ERROR( "FT_Bitmap_Copy", error );
 
     return error == 0 ? true : false;
   }
@@ -128,7 +128,7 @@
     LOG( INFO ) << "embolden bitmap: " << xStrength << " x " << yStrength;
 
     error = FT_Bitmap_Embolden( library, &bitmap, xStrength, yStrength );
-    LOG_IF( ERROR, error != 0 ) << "FT_Bitmap_Embolden failed: " << error;
+    LOG_FT_ERROR( "FT_Bitmap_Embolden", error );
   }
 
 
@@ -156,8 +156,7 @@
                              &target,
                              &target_offset,
                              COLOUR_PINK );
-
-    LOG_IF( ERROR, error != 0 ) << "FT_Bitmap_Blend failed: " << error;
+    LOG_FT_ERROR( "FT_Bitmap_Blend", error );
   }
 
     
@@ -176,6 +175,5 @@
                                &( (FT_BitmapGlyph)glyph.get() )->bitmap,
                                &bitmap,
                                alignment );
-
-    LOG_IF( ERROR, error != 0 ) << "FT_Bitmap_Convert failed: " << error;
+    LOG_FT_ERROR( "FT_Bitmap_Convert", error );
   }

--- a/fuzzing/src/visitors/glyphvisitor-outlines.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-outlines.cpp
@@ -51,29 +51,24 @@
                             glyph_outline->n_points,
                             glyph_outline->n_contours,
                             &outline );
+    LOG_FT_ERROR( "FT_Outline_New", error );
 
     if ( error != 0 )
-    {
-      LOG( ERROR ) << "FT_Outline_New failed: " << error;
       return;
-    }
 
     for ( auto  fn : callbacks )
     {
       error = FT_Outline_Copy( glyph_outline, &outline );
+      LOG_FT_ERROR( "FT_Outline_Copy", error );
 
       if ( error != 0 )
-      {
-        LOG( ERROR ) << "FT_Outline_Copy failed: " << error;
         continue;
-      }
 
       (void) fn( outline );
     }
 
     error = FT_Outline_Done( glyph->library, &outline );
-
-    LOG_IF( ERROR, error != 0 ) << "FT_Outline_Done failed: " << error;
+    LOG_FT_ERROR( "FT_Outline_Done", error );
   }
 
 
@@ -98,8 +93,7 @@
     LOG( INFO ) << "embolden outline by " << strength;
 
     error = FT_Outline_Embolden( &outline, strength );
-
-    LOG_IF( ERROR, error != 0 ) << "FT_Outline_Embolden failed: " << error;
+    LOG_FT_ERROR( "FT_Outline_Embolden", error );
   }
 
 
@@ -116,8 +110,7 @@
                 << xstrength << " x " << ystrength;
 
     error = FT_Outline_EmboldenXY( &outline, xstrength, ystrength );
-
-    LOG_IF( ERROR, error != 0 ) << "FT_Outline_EmboldenXY failed: " << error;
+    LOG_FT_ERROR( "FT_Outline_EmboldenXY", error );
   }
 
 

--- a/fuzzing/src/visitors/glyphvisitor-transform.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-transform.cpp
@@ -57,8 +57,9 @@
              FT_Matrix*              matrix,
              FT_Vector*              delta )
   {
-    FT_Error  error = FT_Glyph_Transform( glyph.get(), matrix, delta );
-    
+    FT_Error  error;
 
-    LOG_IF( ERROR, error != 0 ) << "FT_Glyph_Transform failed: " << error;
+
+    error = FT_Glyph_Transform( glyph.get(), matrix, delta );
+    LOG_FT_ERROR( "FT_Glyph_Transform", error );
   }


### PR DESCRIPTION
- Additionally: reformat some code slightly.