### PR TITLE
Non-zero `FT_Stream` objects can go rogue when thrown at `FT_Stream_C…

### DIFF
--- a/fuzzing/src/utils/FreeTypeStream.h
+++ b/fuzzing/src/utils/FreeTypeStream.h
@@ -71,7 +71,7 @@ namespace freetype {
   private:
 
 
-    FT_StreamRec  stream;
+    FT_StreamRec  stream = {};
   };
 }
 


### PR DESCRIPTION
…lose`.