### PR TITLE
Modernise C++ usage:

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -13,3 +13,6 @@
 [submodule "external/bzip2"]
 	path = external/bzip2
 	url = git://sourceware.org/git/bzip2.git
+[submodule "external/boost"]
+	path = external/boost
+	url = https://github.com/boostorg/boost.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-# Copyright 2018 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -9,6 +9,7 @@
 
 git:
   depth: 1
+  submodules: false
 
 matrix:
   include:

--- a/fuzzing/CMakeLists.txt
+++ b/fuzzing/CMakeLists.txt
@@ -15,7 +15,7 @@
 #   CMAKE_USE_LOGGER_GLOG
 #     (optional) If set and `1', glog will be linked.
 #
-# Copyright 2019 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -51,6 +51,8 @@ set(SUBMODULES_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../external")
 set(FREETYPE_BASE_DIR       "${SUBMODULES_DIR}/freetype2")
 set(FREETYPE_SRC_DIR        "${FREETYPE_BASE_DIR}/src")
 set(FREETYPE_STATIC_LIBRARY "${FREETYPE_BASE_DIR}/objs/.libs/libfreetype.a")
+
+set(BOOST_BASE_DIR "${SUBMODULES_DIR}/boost")
 
 set(GLOG_BASE_DIR       "${SUBMODULES_DIR}/glog")
 set(GLOG_SRC_DIR        "${GLOG_BASE_DIR}/src")
@@ -94,123 +96,123 @@ endfunction()
 
 add_fuzz_target(
   "bdf"
-  "BdfFuzzTarget"
+  "freetype::BdfFuzzTarget"
   "targets/font-drivers/bdf.h")
 add_fuzz_target(
   "bdf-render"
-  "BdfRenderFuzzTarget"
+  "freetype::BdfRenderFuzzTarget"
   "targets/font-drivers/bdf-render.h")
 
 add_fuzz_target(
   "cff"
-  "CffFuzzTarget"
+  "freetype::CffFuzzTarget"
   "targets/font-drivers/cff.h")
 add_fuzz_target(
   "cff-ftengine"
-  "CffFtEngineFuzzTarget"
+  "freetype::CffFtEngineFuzzTarget"
   "targets/font-drivers/cff-ftengine.h")
 add_fuzz_target(
   "cff-render"
-  "CffRenderFuzzTarget"
+  "freetype::CffRenderFuzzTarget"
   "targets/font-drivers/cff-render.h")
 add_fuzz_target(
   "cff-render-ftengine"
-  "CffRenderFtEngineFuzzTarget"
+  "freetype::CffRenderFtEngineFuzzTarget"
   "targets/font-drivers/cff-render-ftengine.h")
 
 add_fuzz_target(
   "cidtype1"
-  "CidType1FuzzTarget"
+  "freetype::CidType1FuzzTarget"
   "targets/font-drivers/cidtype1.h")
 add_fuzz_target(
   "cidtype1-ftengine"
-  "CidType1FtEngineFuzzTarget"
+  "freetype::CidType1FtEngineFuzzTarget"
   "targets/font-drivers/cidtype1-ftengine.h")
 add_fuzz_target(
   "cidtype1-render"
-  "CidType1RenderFuzzTarget"
+  "freetype::CidType1RenderFuzzTarget"
   "targets/font-drivers/cidtype1-render.h")
 add_fuzz_target(
   "cidtype1-render-ftengine"
-  "CidType1RenderFtEngineFuzzTarget"
+  "freetype::CidType1RenderFtEngineFuzzTarget"
   "targets/font-drivers/cidtype1-render-ftengine.h")
 
 add_fuzz_target(
   "pcf"
-  "PcfFuzzTarget"
+  "freetype::PcfFuzzTarget"
   "targets/font-drivers/pcf.h")
 add_fuzz_target(
   "pcf-render"
-  "PcfRenderFuzzTarget"
+  "freetype::PcfRenderFuzzTarget"
   "targets/font-drivers/pcf-render.h")
 
 add_fuzz_target(
   "truetype"
-  "TrueTypeFuzzTarget"
+  "freetype::TrueTypeFuzzTarget"
   "targets/font-drivers/truetype.h")
 add_fuzz_target(
   "truetype-render"
-  "TrueTypeRenderFuzzTarget"
+  "freetype::TrueTypeRenderFuzzTarget"
   "targets/font-drivers/truetype-render.h")
 add_fuzz_target(
   "truetype-render-i35"
-  "TrueTypeRenderI35FuzzTarget"
+  "freetype::TrueTypeRenderI35FuzzTarget"
   "targets/font-drivers/truetype-render-i35.h")
 add_fuzz_target(
   "truetype-render-i38"
-  "TrueTypeRenderI38FuzzTarget"
+  "freetype::TrueTypeRenderI38FuzzTarget"
   "targets/font-drivers/truetype-render-i38.h")
 
 add_fuzz_target(
   "type1"
-  "Type1FuzzTarget"
+  "freetype::Type1FuzzTarget"
   "targets/font-drivers/type1.h")
 add_fuzz_target(
   "type1-ftengine"
-  "Type1FtEngineFuzzTarget"
+  "freetype::Type1FtEngineFuzzTarget"
   "targets/font-drivers/type1-ftengine.h")
 add_fuzz_target(
   "type1-render"
-  "Type1RenderFuzzTarget"
+  "freetype::Type1RenderFuzzTarget"
   "targets/font-drivers/type1-render.h")
 add_fuzz_target(
   "type1-render-ftengine"
-  "Type1RenderFtEngineFuzzTarget"
+  "freetype::Type1RenderFtEngineFuzzTarget"
   "targets/font-drivers/type1-render-ftengine.h")
 add_fuzz_target(
   "type1-render-tar"
-  "Type1RenderTarFuzzTarget"
+  "freetype::Type1RenderTarFuzzTarget"
   "targets/font-drivers/type1-render-tar.h")
 add_fuzz_target(
   "type1-tar"
-  "Type1TarFuzzTarget"
+  "freetype::Type1TarFuzzTarget"
   "targets/font-drivers/type1-tar.h")
 
 add_fuzz_target(
   "type42"
-  "Type42FuzzTarget"
+  "freetype::Type42FuzzTarget"
   "targets/font-drivers/type42.h")
 add_fuzz_target(
   "type42-render"
-  "Type42RenderFuzzTarget"
+  "freetype::Type42RenderFuzzTarget"
   "targets/font-drivers/type42-render.h")
 
 add_fuzz_target(
   "windowsfnt"
-  "WindowsFntFuzzTarget"
+  "freetype::WindowsFntFuzzTarget"
   "targets/font-drivers/windowsfnt.h")
 add_fuzz_target(
   "windowsfnt-render"
-  "WindowsFntRenderFuzzTarget"
+  "freetype::WindowsFntRenderFuzzTarget"
   "targets/font-drivers/windowsfnt-render.h")
 
 add_fuzz_target(
   "glyphs-bitmaps-pcf"
-  "GlyphsBitmapsPcfFuzzTarget"
+  "freetype::GlyphsBitmapsPcfFuzzTarget"
   "targets/glyphs/bitmaps-pcf.h")
 add_fuzz_target(
   "glyphs-outlines"
-  "GlyphsOutlinesFuzzTarget"
+  "freetype::GlyphsOutlinesFuzzTarget"
   "targets/glyphs/outlines.h")
 
 add_fuzz_target(
@@ -245,6 +247,7 @@ endif()
 
 include_directories(
   "${FREETYPE_BASE_DIR}/include"
+  "${BOOST_BASE_DIR}"
   "${FUZZING_SRC_DIR}"
   "${LIBARCHIVE_BASE_DIR}/libarchive")
 

--- a/fuzzing/scripts/build-fuzzers.sh
+++ b/fuzzing/scripts/build-fuzzers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Copyright 2019 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -24,6 +24,7 @@ cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts'
 bash build/libarchive.sh
 bash build/bzip2.sh
 bash build/freetype.sh
+bash build/boost.sh
 bash build/targets.sh
 
 cd "${dir}"

--- a/fuzzing/scripts/build/freetype.sh
+++ b/fuzzing/scripts/build/freetype.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -exo pipefail
 
-# Copyright 2019 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -17,10 +17,8 @@ path_to_freetype=$( readlink -f "../../../external/freetype2" )
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 
-    git submodule init "${path_to_freetype}"
-
     # We always want to run the latest version of FreeType:
-    git submodule update --depth 1 --remote "${path_to_freetype}"
+    git submodule update --init --depth 1 --remote "${path_to_freetype}"
 
     cd "${path_to_freetype}"
 

--- a/fuzzing/scripts/build/libarchive.sh
+++ b/fuzzing/scripts/build/libarchive.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Copyright 2018 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -23,8 +23,7 @@ if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
     # conditionally, based on the installed version of `git', is possible and
     # would save some time when updating submodule.  #goodFirstIssue
 
-    git submodule init   "${path_to_src}"
-    git submodule update "${path_to_src}"
+    git submodule update --init "${path_to_src}"
 
     cd "${path_to_src}"
 

--- a/fuzzing/scripts/cleanup.sh
+++ b/fuzzing/scripts/cleanup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euxo pipefail
 
-# Copyright 2018 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -15,25 +15,9 @@ cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts'
 
 base_path=$( readlink -f ../.. )
 
-path_to_freetype="${base_path}/external/freetype2"
-path_to_glog="${base_path}/external/glog"
-path_to_libarchive="${base_path}/external/libarchive"
-
 cd "${base_path}"
 git reset --hard
 git clean -dfqx
-git checkout "external/*"
-
-cd "${path_to_freetype}"
-git reset --hard
-git clean -dfqx
-
-cd "${path_to_glog}"
-git reset --hard
-git clean -dfqx
-
-cd "${path_to_libarchive}"
-git reset --hard
-git clean -dfqx
+git submodule deinit --all -f
 
 cd "${dir}"

--- a/fuzzing/scripts/custom-build.sh
+++ b/fuzzing/scripts/custom-build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -eo pipefail
 
-# Copyright 2019 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -390,6 +390,7 @@ fi
 bash "build/libarchive.sh"
 bash "build/bzip2.sh"
 bash "build/freetype.sh"
+bash "build/boost.sh"
 bash "build/targets.sh"
 
 cd "${dir}"

--- a/fuzzing/scripts/travis-ci/regression-suite.sh
+++ b/fuzzing/scripts/travis-ci/regression-suite.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -exo pipefail
 
-# Copyright 2019 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -30,6 +30,7 @@ cd ..
 bash build/libarchive.sh
 bash build/bzip2.sh
 bash build/freetype.sh
+bash build/boost.sh
 bash build/targets.sh
 
 cd ../build

--- a/fuzzing/src/driver/CMakeLists.txt
+++ b/fuzzing/src/driver/CMakeLists.txt
@@ -1,6 +1,6 @@
 # CMakeLists.txt
 #
-# Copyright 2019 by
+# Copyright 2018-2019 by
 # Armin Hasitzka.
 #
 # This file is part of the FreeType project, and may only be used, modified,
@@ -11,6 +11,7 @@
 
 add_executable(driver
   "${FUZZING_SRC_DIR}/driver/driver.cpp"
+  "${FUZZING_SRC_DIR}/driver/DriverInternals.cpp"
   "${FUZZING_SRC_DIR}/legacy/ftfuzzer.cc")
 
 set_target_properties(driver PROPERTIES OUTPUT_NAME "${DRIVER_EXE_NAME}")

--- a/fuzzing/src/driver/DriverInternals.cpp
+++ b/fuzzing/src/driver/DriverInternals.cpp
@@ -1,0 +1,157 @@
+// DriverInternals.cpp
+//
+//   Implementation of DriverInternals.
+//
+// Copyright 2018-2019 by
+// Armin Hasitzka.
+//
+// This file is part of the FreeType project, and may only be used,
+// modified, and distributed under the terms of the FreeType project
+// license, LICENSE.TXT.  By continuing to use, modify, or distribute
+// this file you indicate that you have read the license and
+// understand and accept it fully.
+
+
+#include "driver/DriverInternals.h"
+
+#include <iostream>
+
+#include "targets/font-drivers/bdf.h"
+#include "targets/font-drivers/bdf-render.h"
+
+#include "targets/font-drivers/cff.h"
+#include "targets/font-drivers/cff-ftengine.h"
+#include "targets/font-drivers/cff-render.h"
+#include "targets/font-drivers/cff-render-ftengine.h"
+
+#include "targets/font-drivers/cidtype1.h"
+#include "targets/font-drivers/cidtype1-ftengine.h"
+#include "targets/font-drivers/cidtype1-render.h"
+#include "targets/font-drivers/cidtype1-render-ftengine.h"
+
+#include "targets/font-drivers/pcf.h"
+#include "targets/font-drivers/pcf-render.h"
+
+#include "targets/font-drivers/truetype.h"
+#include "targets/font-drivers/truetype-render.h"
+#include "targets/font-drivers/truetype-render-i35.h"
+#include "targets/font-drivers/truetype-render-i38.h"
+
+#include "targets/font-drivers/type1.h"
+#include "targets/font-drivers/type1-ftengine.h"
+#include "targets/font-drivers/type1-render.h"
+#include "targets/font-drivers/type1-render-ftengine.h"
+#include "targets/font-drivers/type1-render-tar.h"
+#include "targets/font-drivers/type1-tar.h"
+
+#include "targets/font-drivers/type42.h"
+#include "targets/font-drivers/type42-render.h"
+
+#include "targets/font-drivers/windowsfnt.h"
+#include "targets/font-drivers/windowsfnt-render.h"
+
+#include "targets/glyphs/outlines.h"
+#include "targets/glyphs/bitmaps-pcf.h"
+
+#include "targets/support/Bzip2FuzzTarget.h"
+#include "targets/support/GzipFuzzTarget.h"
+#include "targets/support/LzwFuzzTarget.h"
+
+
+  // The legacy fuzzer is a monolith but it is the only target that calls
+  // LLVMFuzzerTestOneInput( ... ) directly which is why we get away with
+  // using it to invoke the legacy target.
+
+  extern "C" int
+  LLVMFuzzerTestOneInput( const uint8_t*  data,
+                          size_t          size );
+
+
+  freetype::DriverInternals::
+  DriverInternals()
+  {
+    (void) add<BdfFuzzTarget>(       "bdf" );
+    (void) add<BdfRenderFuzzTarget>( "bdf-render" );
+
+    (void) add<CffFuzzTarget>(               "cff" );
+    (void) add<CffFtEngineFuzzTarget>(       "cff-ftengine" );
+    (void) add<CffRenderFuzzTarget>(         "cff-render" );
+    (void) add<CffRenderFtEngineFuzzTarget>( "cff-render-ftengine" );
+
+    (void) add<CidType1FuzzTarget>(               "cidtype1" );
+    (void) add<CidType1FtEngineFuzzTarget>(       "cidtype1-ftengine" );
+    (void) add<CidType1RenderFuzzTarget>(         "cidtype1-render" );
+    (void) add<CidType1RenderFtEngineFuzzTarget>( "cidtype1-render-ftengine" );
+
+    (void) add<PcfFuzzTarget>(       "pcf" );
+    (void) add<PcfRenderFuzzTarget>( "pcf-render" );
+
+    (void) add<TrueTypeFuzzTarget>(          "truetype" );
+    (void) add<TrueTypeRenderFuzzTarget>(    "truetype-render" );
+    (void) add<TrueTypeRenderI35FuzzTarget>( "truetype-render-i35" );
+    (void) add<TrueTypeRenderI38FuzzTarget>( "truetype-render-i38" );
+
+    (void) add<Type1FuzzTarget>(               "type1" );
+    (void) add<Type1FtEngineFuzzTarget>(       "type1-ftengine" );
+    (void) add<Type1RenderFtEngineFuzzTarget>( "type1-tar" );
+    (void) add<Type1RenderFuzzTarget>(         "type1-render" );
+    (void) add<Type1RenderFtEngineFuzzTarget>( "type1-render-ftengine" );
+    (void) add<Type1RenderFtEngineFuzzTarget>( "type1-render-tar" );
+
+    (void) add<Type42FuzzTarget>(       "type42" );
+    (void) add<Type42RenderFuzzTarget>( "type42-render" );
+
+    (void) add<WindowsFntFuzzTarget>(       "windowsfnt" );
+    (void) add<WindowsFntRenderFuzzTarget>( "windowsfnt-render" );
+
+    (void) add<GlyphsOutlinesFuzzTarget>(   "glyphs-outlines" );
+    (void) add<GlyphsBitmapsPcfFuzzTarget>( "glyphs-bitmaps-pcf" );
+
+    (void) add<GzipFuzzTarget>(  "gzip" );
+    (void) add<LzwFuzzTarget>(   "lzw" );
+    (void) add<Bzip2FuzzTarget>( "bzip2" );
+  }
+
+
+  bool
+  freetype::DriverInternals::
+  run( const std::string& type_arg,
+       const uint8_t*     data,
+       size_t             size )
+  {
+    if ( type_arg == "--legacy" ) {
+      (void) LLVMFuzzerTestOneInput( data, size );
+      return true;
+    }
+
+    auto target = targets.find( type_arg );
+    if ( target == targets.end() )
+      return false;
+
+    (void) target->second( data, size );
+
+    return true;
+  }
+
+
+  void
+  freetype::DriverInternals::
+  print_error( const std::string&  message )
+  {
+    std::cerr << message << "\n";
+  }
+
+
+  void
+  freetype::DriverInternals::
+  print_usage()
+  {
+    std::cerr << "\nUsage: driver TYPE FILE\n\n"
+              << "Type:\n\n";
+
+    for ( auto  t : usage_types )
+      std::cerr << "  --" << t << "\n";
+
+    std::cerr << "\nFile:\n\n"
+              << "  The location (path) of an input file.\n\n";
+  }

--- a/fuzzing/src/driver/DriverInternals.h
+++ b/fuzzing/src/driver/DriverInternals.h
@@ -1,0 +1,84 @@
+// DriverInternals.h
+//
+//   Driver internals.
+//
+// Copyright 2018-2019 by
+// Armin Hasitzka.
+//
+// This file is part of the FreeType project, and may only be used,
+// modified, and distributed under the terms of the FreeType project
+// license, LICENSE.TXT.  By continuing to use, modify, or distribute
+// this file you indicate that you have read the license and
+// understand and accept it fully.
+
+
+#ifndef DRIVER_DRIVERINTERNALS_H_
+#define DRIVER_DRIVERINTERNALS_H_
+
+
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <boost/core/noncopyable.hpp>
+
+
+namespace freetype {
+
+
+  class DriverInternals
+    : private boost::noncopyable
+  {
+  public:
+
+
+    DriverInternals();
+
+
+    bool
+    run( const std::string& type_arg,
+         const uint8_t*     data,
+         size_t             size );
+
+
+    void
+    print_error( const std::string&  message );
+
+
+    void
+    print_usage();
+
+
+  private:
+
+
+    typedef void (*RunFunc)( const uint8_t*, size_t );
+
+    typedef std::unordered_map<std::string, RunFunc>  FuzzTargets;
+
+    FuzzTargets               targets;
+    std::vector<std::string>  usage_types;
+
+
+    template<class T>
+    static void
+    run( const uint8_t*  data,
+         size_t          size )
+    {
+      // Late initialisation:
+      (void) ( T() ).run( data, size );
+    }
+
+
+    template<class T>
+    void
+    add( const std::string&  name )
+    {
+      (void) targets.insert( std::make_pair( "--" + name, run<T> ) );
+      (void) usage_types.push_back( name );
+    }
+  };
+}
+
+
+#endif // DRIVER_DRIVERINTERNALS_H_

--- a/fuzzing/src/driver/driver.cpp
+++ b/fuzzing/src/driver/driver.cpp
@@ -2,7 +2,7 @@
 //
 //   Entry point of the test driver.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,115 +14,11 @@
 
 #include <cstdlib>
 #include <fstream>
-#include <iostream>
+#include <string>
 #include <vector>
 
-#include "targets/font-drivers/bdf.h"
-#include "targets/font-drivers/bdf-render.h"
-
-#include "targets/font-drivers/cff.h"
-#include "targets/font-drivers/cff-ftengine.h"
-#include "targets/font-drivers/cff-render.h"
-#include "targets/font-drivers/cff-render-ftengine.h"
-
-#include "targets/font-drivers/cidtype1.h"
-#include "targets/font-drivers/cidtype1-ftengine.h"
-#include "targets/font-drivers/cidtype1-render.h"
-#include "targets/font-drivers/cidtype1-render-ftengine.h"
-
-#include "targets/font-drivers/pcf.h"
-#include "targets/font-drivers/pcf-render.h"
-
-#include "targets/font-drivers/truetype.h"
-#include "targets/font-drivers/truetype-render.h"
-#include "targets/font-drivers/truetype-render-i35.h"
-#include "targets/font-drivers/truetype-render-i38.h"
-
-#include "targets/font-drivers/type1.h"
-#include "targets/font-drivers/type1-ftengine.h"
-#include "targets/font-drivers/type1-render.h"
-#include "targets/font-drivers/type1-render-ftengine.h"
-#include "targets/font-drivers/type1-render-tar.h"
-#include "targets/font-drivers/type1-tar.h"
-
-#include "targets/font-drivers/type42.h"
-#include "targets/font-drivers/type42-render.h"
-
-#include "targets/font-drivers/windowsfnt.h"
-#include "targets/font-drivers/windowsfnt-render.h"
-
-#include "targets/glyphs/outlines.h"
-#include "targets/glyphs/bitmaps-pcf.h"
-
-#include "targets/support/Bzip2FuzzTarget.h"
-#include "targets/support/GzipFuzzTarget.h"
-#include "targets/support/LzwFuzzTarget.h"
-
+#include "driver/DriverInternals.h"
 #include "utils/logging.h"
-
-
-  using namespace std;
-
-
-  // The legacy fuzzer is a monolith but it is the only target that calls
-  // LLVMFuzzerTestOneInput( ... ) directly which is why we get away with
-  // using it to invoke the legacy target.
-
-  extern "C" int
-  LLVMFuzzerTestOneInput( const uint8_t*  data,
-                          size_t          size );
-
-
-  int
-  print_error( const string&  message )
-  {
-    cerr << message << "\n";
-
-    return EXIT_FAILURE;
-  }
-
-
-  int
-  print_usage( void )
-  {
-    return print_error( "\nUsage: driver TYPE FILE\n\n"                 \
-                        "Type:\n\n"                                     \
-                        "  --legacy\n\n"                                \
-                        "  --bdf\n"                                     \
-                        "  --bdf-render\n\n"                            \
-                        "  --cff\n"                                     \
-                        "  --cff-ftengine\n"                            \
-                        "  --cff-render\n"                              \
-                        "  --cff-render-ftengine\n\n"                   \
-                        "  --cidtype1\n"                                \
-                        "  --cidtype1-ftengine\n"                       \
-                        "  --cidtype1-render\n"                         \
-                        "  --cidtype1-render-ftengine\n\n"              \
-                        "  --pcf\n"                                     \
-                        "  --pcf-render\n\n"                            \
-                        "  --truetype\n"                                \
-                        "  --truetype-render\n"                         \
-                        "  --truetype-render-i35\n"                     \
-                        "  --truetype-render-i38\n\n"                   \
-                        "  --type1\n"                                   \
-                        "  --type1-ftengine\n"                          \
-                        "  --type1-render\n"                            \
-                        "  --type1-render-ftengine\n"                   \
-                        "  --type1-render-tar\n"                        \
-                        "  --type1-tar\n\n"                             \
-                        "  --type42\n"                                  \
-                        "  --type42-render\n\n"                         \
-                        "  --windowsfnt\n"                              \
-                        "  --windowsfnt-render\n\n"                     \
-                        "  --glyphs-outlines\n\n"                       \
-                        "  --glyphs-bitmaps-pcf\n\n"                    \
-                        "  --gzip\n"                                    \
-                        "  --lzw\n"                                     \
-                        "  --bzip2\n\n"                                 \
-                        "File:\n\n"                                     \
-                        "  The location (path) of an input file.\n" );
-  }
-
 
   int
   main( int     argc,
@@ -130,106 +26,39 @@
   {
 
 #ifdef LOGGER_GLOG
-  (void) google::InitGoogleLogging( argv[0] );
+    (void) google::InitGoogleLogging( argv[0] );
 #endif // LOGGER_GLOG
 
+    freetype::DriverInternals internals;
+
     if ( argc != 3 )
-      return print_usage();
+    {
+      (void) internals.print_usage();
+      return EXIT_FAILURE;
+    }
 
-    string  input_file_arg( argv[2] );
+    std::string  input_file_arg( argv[2] );
 
-    ifstream  input_file( input_file_arg, ios_base::binary );
+    std::ifstream  input_file( input_file_arg, std::ios_base::binary );
     if ( input_file.is_open() == false )
-      return print_error( "error: invalid file '" + input_file_arg + "'");
+    {
+      (void) internals.print_error(
+        "error: invalid file '" + input_file_arg + "'" );
+      return EXIT_FAILURE;
+    }
 
-    vector<char>  input( ( istreambuf_iterator<char>( input_file ) ),
-                         istreambuf_iterator<char>() );
+    std::vector<char>  input( ( std::istreambuf_iterator<char>( input_file ) ),
+                                std::istreambuf_iterator<char>() );
 
     (void) input_file.close();
 
-    uint8_t*  data = reinterpret_cast<uint8_t*>( input.data() );
-    size_t    size = input.size();
-
-    string  type_arg( argv[1] );
-
-    if ( type_arg == "--legacy" )
-      (void) LLVMFuzzerTestOneInput(                     data, size );
-
-    else if ( type_arg == "--bdf" )
-      (void) ( BdfFuzzTarget()                    ).run( data, size );
-    else if ( type_arg == "--bdf-render" )
-      (void) ( BdfRenderFuzzTarget()              ).run( data, size );
-
-    else if ( type_arg == "--cff" )
-      (void) ( CffFuzzTarget()                    ).run( data, size );
-    else if ( type_arg == "--cff-ftengine" )
-      (void) ( CffFtEngineFuzzTarget()            ).run( data, size );
-    else if ( type_arg == "--cff-render" )
-      (void) ( CffRenderFuzzTarget()              ).run( data, size );
-    else if ( type_arg == "--cff-render-ftengine" )
-      (void) ( CffRenderFtEngineFuzzTarget()      ).run( data, size );
-
-    else if ( type_arg == "--cidtype1" )
-      (void) ( CidType1FuzzTarget()               ).run( data, size );
-    else if ( type_arg == "--cidtype1-ftengine" )
-      (void) ( CidType1FtEngineFuzzTarget()       ).run( data, size );
-    else if ( type_arg == "--cidtype1-render" )
-      (void) ( CidType1RenderFuzzTarget()         ).run( data, size );
-    else if ( type_arg == "--cidtype1-render-ftengine" )
-      (void) ( CidType1RenderFtEngineFuzzTarget() ).run( data, size );
-
-    else if ( type_arg == "--pcf" )
-      (void) ( PcfFuzzTarget()                    ).run( data, size );
-    else if ( type_arg == "--pcf-render" )
-      (void) ( PcfRenderFuzzTarget()              ).run( data, size );
-
-    else if ( type_arg == "--truetype" )
-      (void) ( TrueTypeFuzzTarget()               ).run( data, size );
-    else if ( type_arg == "--truetype-render" )
-      (void) ( TrueTypeRenderFuzzTarget()         ).run( data, size );
-    else if ( type_arg == "--truetype-render-i35" )
-      (void) ( TrueTypeRenderI35FuzzTarget()      ).run( data, size );
-    else if ( type_arg == "--truetype-render-i38" )
-      (void) ( TrueTypeRenderI38FuzzTarget()      ).run( data, size );
-
-    else if ( type_arg == "--type1" )
-      (void) ( Type1FuzzTarget()                  ).run( data, size );
-    else if ( type_arg == "--type1-ftengine" )
-      (void) ( Type1FtEngineFuzzTarget()          ).run( data, size );
-    else if ( type_arg == "--type1-render" )
-      (void) ( Type1RenderFuzzTarget()            ).run( data, size );
-    else if ( type_arg == "--type1-render-ftengine" )
-      (void) ( Type1RenderFtEngineFuzzTarget()    ).run( data, size );
-    else if ( type_arg == "--type1-render-tar" )
-      (void) ( Type1RenderTarFuzzTarget()         ).run( data, size );
-    else if ( type_arg == "--type1-tar" )
-      (void) ( Type1TarFuzzTarget()               ).run( data, size );
-
-    else if ( type_arg == "--type42" )
-      (void) ( Type42FuzzTarget()                 ).run( data, size );
-    else if ( type_arg == "--type42-render" )
-      (void) ( Type42RenderFuzzTarget()           ).run( data, size );
-
-    else if ( type_arg == "--windowsfnt" )
-      (void) ( WindowsFntFuzzTarget()             ).run( data, size );
-    else if ( type_arg == "--windowsfnt-render" )
-      (void) ( WindowsFntRenderFuzzTarget()       ).run( data, size );
-
-    else if ( type_arg == "--glyphs-outlines" )
-      (void) ( GlyphsOutlinesFuzzTarget()         ).run( data, size );
-
-    else if ( type_arg == "--glyphs-bitmaps-pcf" )
-      (void) ( GlyphsBitmapsPcfFuzzTarget()       ).run( data, size );
-
-    else if ( type_arg == "--gzip" )
-      (void) ( freetype::GzipFuzzTarget()         ).run( data, size );
-    else if ( type_arg == "--lzw" )
-      (void) ( freetype::LzwFuzzTarget()          ).run( data, size );
-    else if ( type_arg == "--bzip2" )
-      (void) ( freetype::Bzip2FuzzTarget()        ).run( data, size );
-
-    else
-      return print_usage();
+    if ( internals.run( argv[1],
+                        reinterpret_cast<uint8_t*>( input.data() ),
+                        input.size() ) == false )
+    {
+      (void) internals.print_usage();
+      return EXIT_FAILURE;
+    }
 
     return EXIT_SUCCESS;
   }

--- a/fuzzing/src/fuzzers/template.cpp
+++ b/fuzzing/src/fuzzers/template.cpp
@@ -6,7 +6,7 @@
 //     - `FUZZ_TARGET_CLASS_NAME':
 //         The class name of the target.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -20,6 +20,7 @@
 
 
 namespace {
+
 
   FUZZ_TARGET_CLASS_NAME  target;
 

--- a/fuzzing/src/iterators/faceloaditerator.cpp
+++ b/fuzzing/src/iterators/faceloaditerator.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceLoadIterator.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,16 +15,12 @@
 #include "iterators/faceloaditerator.h"
 
 #include <cassert>
-#include <memory>
-
-#include <ft2build.h>
-#include FT_FREETYPE_H
 
 #include "utils/logging.h"
 
 
   void
-  FaceLoadIterator::
+  freetype::FaceLoadIterator::
   set_supported_font_format( FaceLoader::FontFormat  format )
   {
     assert( face_loader != nullptr );
@@ -33,7 +29,7 @@
 
 
   void
-  FaceLoadIterator::
+  freetype::FaceLoadIterator::
   set_library( FT_Library  library )
   {
     assert( face_loader != nullptr );
@@ -42,7 +38,7 @@
 
 
   void
-  FaceLoadIterator::
+  freetype::FaceLoadIterator::
   set_raw_bytes( const uint8_t*  data,
                  size_t          size )
   {
@@ -52,7 +48,7 @@
 
 
   void
-  FaceLoadIterator::
+  freetype::FaceLoadIterator::
   set_data_is_tar_archive( bool  is_tar_archive )
   {
     assert( face_loader != nullptr );
@@ -61,32 +57,32 @@
 
 
   void
-  FaceLoadIterator::
-  add_once_visitor( unique_ptr<FaceVisitor>  visitor )
+  freetype::FaceLoadIterator::
+  add_once_visitor( std::unique_ptr<FaceVisitor>  visitor )
   {
     (void) once_face_visitors.emplace_back( move( visitor ) );
   }
 
 
   void
-  FaceLoadIterator::
-  add_always_visitor( unique_ptr<FaceVisitor>  visitor )
+  freetype::FaceLoadIterator::
+  add_always_visitor( std::unique_ptr<FaceVisitor>  visitor )
   {
     (void) always_face_visitors.emplace_back( move( visitor ) );
   }
 
 
   void
-  FaceLoadIterator::
-  add_iterator( unique_ptr<FacePrepIterator>  iterator )
+  freetype::FaceLoadIterator::
+  add_iterator( std::unique_ptr<FacePrepIterator>  iterator )
   {
     (void) face_prep_iterators.emplace_back( move( iterator ) );
   }
 
 
   void
-  FaceLoadIterator::
-  run( void )
+  freetype::FaceLoadIterator::
+  run()
   {
     Unique_FT_Face  face = make_unique_face();
 
@@ -115,7 +111,7 @@
 
       if ( face_index == 0 )
       {
-        LOG( INFO ) << "fs type flags: 0x" << hex
+        LOG( INFO ) << "fs type flags: 0x" << std::hex
                     << FT_Get_FSType_Flags( face.get() );
 
         for ( auto&  visitor : once_face_visitors )

--- a/fuzzing/src/iterators/faceloaditerator.h
+++ b/fuzzing/src/iterators/faceloaditerator.h
@@ -2,7 +2,7 @@
 //
 //   Base class of iterators over faces.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -16,27 +16,30 @@
 #define ITERATORS_FACE_LOAD_ITERATOR_H_
 
 
+#include <memory> // std::unique_ptr
+
+#include <boost/core/noncopyable.hpp>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
 #include "iterators/faceprepiterator.h"
 #include "utils/faceloader.h"
 #include "utils/utils.h"
 #include "visitors/facevisitor.h"
 
 
-  using namespace fuzzing;
-  using namespace std;
+namespace freetype {
 
 
   class FaceLoadIterator
+    : private boost::noncopyable
   {
   public:
 
     
-    FaceLoadIterator( void )
+    FaceLoadIterator()
       : face_loader( new FaceLoader ) {}
-
-
-    FaceLoadIterator( const FaceLoadIterator& ) = delete;
-    FaceLoadIterator& operator= ( const FaceLoadIterator& ) = delete;
 
 
     // @See: FaceLoader::set_supported_font_format
@@ -72,7 +75,7 @@
     //     A face visitor.
 
     void
-    add_once_visitor( unique_ptr<FaceVisitor>  visitor );
+    add_once_visitor( std::unique_ptr<FaceVisitor>  visitor );
 
 
     // @Description:
@@ -83,7 +86,7 @@
     //     A face visitor.
 
     void
-    add_always_visitor( unique_ptr<FaceVisitor>  visitor );
+    add_always_visitor( std::unique_ptr<FaceVisitor>  visitor );
 
 
     // @Description:
@@ -95,7 +98,7 @@
     //     A face preparation iterator.
 
     void
-    add_iterator( unique_ptr<FacePrepIterator>  iterator );
+    add_iterator( std::unique_ptr<FacePrepIterator>  iterator );
 
 
     // @Description:
@@ -103,7 +106,7 @@
     //   visitors.
 
     void
-    run( void );
+    run();
 
 
   private:
@@ -112,13 +115,14 @@
     static const FT_Long  FACE_INDEX_MAX     = 5;
     static const FT_Long  INSTANCE_INDEX_MAX = 5;
 
-    unique_ptr<FaceLoader>  face_loader;
+    std::unique_ptr<FaceLoader>  face_loader;
 
-    vector<unique_ptr<FaceVisitor>>  once_face_visitors;
-    vector<unique_ptr<FaceVisitor>>  always_face_visitors;
+    std::vector<std::unique_ptr<FaceVisitor>>  once_face_visitors;
+    std::vector<std::unique_ptr<FaceVisitor>>  always_face_visitors;
 
-    vector<unique_ptr<FacePrepIterator>>  face_prep_iterators;
+    std::vector<std::unique_ptr<FacePrepIterator>>  face_prep_iterators;
   };
+}
 
 
 #endif // ITERATORS_FACE_LOAD_ITERATOR_H_

--- a/fuzzing/src/iterators/faceprepiterator-bitmaps.cpp
+++ b/fuzzing/src/iterators/faceprepiterator-bitmaps.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FacePrepIteratorBitmaps.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -20,8 +20,8 @@
 
 
   void
-  FacePrepIteratorBitmaps::
-  run( const unique_ptr<FaceLoader>&  face_loader )
+  freetype::FacePrepIteratorBitmaps::
+  run( const std::unique_ptr<FaceLoader>&  face_loader )
   {
     Unique_FT_Face  face = make_unique_face();
     FT_Int          num_strikes;
@@ -64,10 +64,10 @@
   }
 
 
-  Unique_FT_Face
-  FacePrepIteratorBitmaps::
-  get_prepared_face( const unique_ptr<FaceLoader>&  face_loader,
-                     FT_Int                         index )
+  freetype::Unique_FT_Face
+  freetype::FacePrepIteratorBitmaps::
+  get_prepared_face( const std::unique_ptr<FaceLoader>&  face_loader,
+                     FT_Int                              index )
   {
     FT_Error  error;
 

--- a/fuzzing/src/iterators/faceprepiterator-bitmaps.h
+++ b/fuzzing/src/iterators/faceprepiterator-bitmaps.h
@@ -2,7 +2,7 @@
 //
 //   Iterator that prepares faces for bitmap usage.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -16,36 +16,20 @@
 #define ITERATORS_FACE_PREP_ITERATOR_BITMAPS_H_
 
 
-#include <vector>
-
 #include "iterators/faceprepiterator.h"
 
 
-  using namespace fuzzing;
-  using namespace std;
+namespace freetype {
 
 
   class FacePrepIteratorBitmaps
-  : public FacePrepIterator
+    : public FacePrepIterator
   {
   public:
 
 
-    FacePrepIteratorBitmaps( void ) {}
-    
-
-    FacePrepIteratorBitmaps(
-      const FacePrepIteratorBitmaps& ) = delete;
-    FacePrepIteratorBitmaps& operator= (
-      const FacePrepIteratorBitmaps& ) = delete;
-
-
-    virtual
-    ~FacePrepIteratorBitmaps( void ) {}
-
-
     void
-    run( const unique_ptr<FaceLoader>&  face_loader )
+    run( const std::unique_ptr<FaceLoader>&  face_loader )
     override;
 
 
@@ -56,9 +40,10 @@
 
 
     Unique_FT_Face
-    get_prepared_face( const unique_ptr<FaceLoader>&  face_loader,
-                       FT_Int                         index );
+    get_prepared_face( const std::unique_ptr<FaceLoader>&  face_loader,
+                       FT_Int                              index );
   };
+}
 
 
 #endif // ITERATORS_FACE_PREP_ITERATOR_BITMAPS_H_

--- a/fuzzing/src/iterators/faceprepiterator-multiplemasters.cpp
+++ b/fuzzing/src/iterators/faceprepiterator-multiplemasters.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FacePrepIteratorMultipleMasters.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -17,19 +17,19 @@
 #include "utils/logging.h"
 
 
-  Unique_FT_Face
-  FacePrepIteratorMultipleMasters::
-  get_prepared_face( const unique_ptr<FaceLoader>&     face_loader,
-                     vector<CharSizeTuple>::size_type  index )
+  freetype::Unique_FT_Face
+  freetype::FacePrepIteratorMultipleMasters::
+  get_prepared_face( const std::unique_ptr<FaceLoader>&  face_loader,
+                     CharSizeTuples::size_type           index )
   {
     FT_Error  error;
 
     Unique_FT_Face  face =
       FacePrepIteratorOutlines::get_prepared_face( face_loader, index );
 
-    FT_Library        library;
-    FT_MM_Var*        master;
-    vector<FT_Fixed>  coords;
+    FT_Library             library;
+    FT_MM_Var*             master;
+    std::vector<FT_Fixed>  coords;
 
 
     if ( face == nullptr )
@@ -68,8 +68,8 @@
   }
 
 
-  Unique_FT_Face
-  FacePrepIteratorMultipleMasters::
+  freetype::Unique_FT_Face
+  freetype::FacePrepIteratorMultipleMasters::
   free_and_return( FT_Library      library,
                    FT_MM_Var*      master,
                    Unique_FT_Face  face )

--- a/fuzzing/src/iterators/faceprepiterator-multiplemasters.h
+++ b/fuzzing/src/iterators/faceprepiterator-multiplemasters.h
@@ -2,7 +2,7 @@
 //
 //   Iterator that prepares faces for outline usage with multiple masters.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -16,42 +16,24 @@
 #define ITERATORS_FACE_PREP_ITERATOR_MULTIPLE_MASTERS_H_
 
 
-#include <vector>
-
 #include <ft2build.h>
 #include FT_MULTIPLE_MASTERS_H
 
 #include "iterators/faceprepiterator-outlines.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FacePrepIteratorMultipleMasters
-  : public FacePrepIteratorOutlines
+    : public FacePrepIteratorOutlines
   {
-  public:
-
-
-    FacePrepIteratorMultipleMasters( void ) {}
-    
-
-    FacePrepIteratorMultipleMasters(
-      const FacePrepIteratorMultipleMasters& ) = delete;
-    FacePrepIteratorMultipleMasters& operator= (
-      const FacePrepIteratorMultipleMasters& ) = delete;
-
-
-    virtual
-    ~FacePrepIteratorMultipleMasters( void ) {}
-
-
   protected:
 
 
-    virtual Unique_FT_Face
-    get_prepared_face( const unique_ptr<FaceLoader>&     face_loader,
-                       vector<CharSizeTuple>::size_type  index )
+    Unique_FT_Face
+    get_prepared_face( const std::unique_ptr<FaceLoader>&  face_loader,
+                       CharSizeTuples::size_type           index )
     override;
 
 
@@ -66,6 +48,7 @@
                      FT_MM_Var*      master,
                      Unique_FT_Face  face );
   };
+}
 
 
 #endif // ITERATORS_FACE_PREP_ITERATOR_MULTIPLE_MASTERS_H_

--- a/fuzzing/src/iterators/faceprepiterator-outlines.h
+++ b/fuzzing/src/iterators/faceprepiterator-outlines.h
@@ -2,7 +2,7 @@
 //
 //   Iterator that prepares faces for outline usage.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,44 +15,39 @@
 #ifndef ITERATORS_FACE_PREP_ITERATOR_OUTLINES_H_
 #define ITERATORS_FACE_PREP_ITERATOR_OUTLINES_H_
 
+
+#include <memory> // std::unique_ptr
+#include <tuple>
 #include <vector>
 
 #include "iterators/faceprepiterator.h"
 
 
-  using namespace std;
-
-
-  typedef tuple<
-    FT_UInt,                 // pixel width
-    FT_UInt,                 // pixel height
-    FT_F26Dot6,              // char width
-    FT_F26Dot6,              // char height
-    FT_UInt,                 // horz resolution
-    FT_UInt>  CharSizeTuple; // vert resolution
+namespace freetype {
 
 
   class FacePrepIteratorOutlines
-  : public FacePrepIterator
+    : public FacePrepIterator
   {
   public:
 
 
-    FacePrepIteratorOutlines( void );
-    
+    typedef std::tuple<
+      FT_UInt,                 // pixel width
+      FT_UInt,                 // pixel height
+      FT_F26Dot6,              // char width
+      FT_F26Dot6,              // char height
+      FT_UInt,                 // horz resolution
+      FT_UInt>  CharSizeTuple; // vert resolution
 
-    FacePrepIteratorOutlines(
-      const FacePrepIteratorOutlines& ) = delete;
-    FacePrepIteratorOutlines& operator= (
-      const FacePrepIteratorOutlines& ) = delete;
+    typedef std::vector<CharSizeTuple>  CharSizeTuples;
 
 
-    virtual
-    ~FacePrepIteratorOutlines( void ) {}
+    FacePrepIteratorOutlines();
 
 
     void
-    run( const unique_ptr<FaceLoader>&  face_loader )
+    run( const std::unique_ptr<FaceLoader>&  face_loader )
     override;
 
 
@@ -60,14 +55,14 @@
 
 
     virtual Unique_FT_Face
-    get_prepared_face( const unique_ptr<FaceLoader>&     face_loader,
-                       vector<CharSizeTuple>::size_type  index );
+    get_prepared_face( const std::unique_ptr<FaceLoader>&  face_loader,
+                       CharSizeTuples::size_type           index );
 
 
   private:
 
 
-    vector<CharSizeTuple>  char_sizes;
+    CharSizeTuples  char_sizes;
 
       
     // @Description:
@@ -100,6 +95,7 @@
                       FT_UInt     horz_resolution_dpi,
                       FT_UInt     vert_resolution_dpi );
   };
+}
 
 
 #endif // ITERATORS_FACE_PREP_ITERATOR_OUTLINES_H_

--- a/fuzzing/src/iterators/faceprepiterator.cpp
+++ b/fuzzing/src/iterators/faceprepiterator.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FacePrepIterator.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,23 +14,20 @@
 
 #include "iterators/faceprepiterator.h"
 
-#include <ft2build.h>
-#include FT_FREETYPE_H
-
-#include "utils/logging.h"
+#include <utility> // std::move
 
 
   void
-  FacePrepIterator::
-  add_visitor( unique_ptr<FaceVisitor>  visitor )
+  freetype::FacePrepIterator::
+  add_visitor( std::unique_ptr<FaceVisitor>  visitor )
   {
-    (void) face_visitors.emplace_back( move( visitor ) );
+    (void) face_visitors.emplace_back( std::move( visitor ) );
   }
 
 
   void
-  FacePrepIterator::
-  add_iterator( unique_ptr<GlyphLoadIterator>  iterator )
+  freetype::FacePrepIterator::
+  add_iterator( std::unique_ptr<GlyphLoadIterator>  iterator )
   {
-    (void) glyph_load_iterators.emplace_back( move( iterator ) );
+    (void) glyph_load_iterators.emplace_back( std::move( iterator ) );
   }

--- a/fuzzing/src/iterators/faceprepiterator.h
+++ b/fuzzing/src/iterators/faceprepiterator.h
@@ -2,7 +2,7 @@
 //
 //   Base class of iterators that prepare faces.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -16,26 +16,27 @@
 #define ITERATORS_FACE_PREP_ITERATOR_H_
 
 
+#include <memory> // std::unique_ptr
+
+#include <boost/core/noncopyable.hpp>
+
 #include "iterators/glyphloaditerator.h"
 #include "utils/faceloader.h"
 #include "utils/utils.h"
 #include "visitors/facevisitor.h"
 
 
+namespace freetype {
+
+
   class FacePrepIterator
+    : private boost::noncopyable
   {
   public:
 
 
-    FacePrepIterator( void ) {}
-
-
-    FacePrepIterator( const FacePrepIterator& ) = delete;
-    FacePrepIterator& operator= ( const FacePrepIterator& ) = delete;
-
-
     virtual
-    ~FacePrepIterator( void ) {}
+    ~FacePrepIterator() = default;
 
 
     // @Description:
@@ -49,7 +50,7 @@
     //   A reference to the added visitor.
 
     void
-    add_visitor( unique_ptr<FaceVisitor>  visitor );
+    add_visitor( std::unique_ptr<FaceVisitor>  visitor );
 
 
     // @Description:
@@ -63,19 +64,20 @@
     //   A reference to the added iterator.
 
     void
-    add_iterator( unique_ptr<GlyphLoadIterator>  iterator );
+    add_iterator( std::unique_ptr<GlyphLoadIterator>  iterator );
 
 
     virtual void
-    run( const unique_ptr<FaceLoader>&  face_loader ) = 0;
+    run( const std::unique_ptr<FaceLoader>&  face_loader ) = 0;
 
 
   protected:
 
 
-    vector<unique_ptr<FaceVisitor>>        face_visitors;
-    vector<unique_ptr<GlyphLoadIterator>>  glyph_load_iterators;
+    std::vector<std::unique_ptr<FaceVisitor>>        face_visitors;
+    std::vector<std::unique_ptr<GlyphLoadIterator>>  glyph_load_iterators;
   };
+}
 
 
 #endif // ITERATORS_FACE_PREP_ITERATOR_H_

--- a/fuzzing/src/iterators/glyphloaditerator-naive.cpp
+++ b/fuzzing/src/iterators/glyphloaditerator-naive.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphLoadIteratorNaive.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -20,7 +20,7 @@
 
 
   void
-  GlyphLoadIteratorNaive::
+  freetype::GlyphLoadIteratorNaive::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;

--- a/fuzzing/src/iterators/glyphloaditerator-naive.h
+++ b/fuzzing/src/iterators/glyphloaditerator-naive.h
@@ -2,7 +2,7 @@
 //
 //   Iterator that, naively, loads every available glyph.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,27 +19,17 @@
 #include "iterators/glyphloaditerator.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class GlyphLoadIteratorNaive
-  : public GlyphLoadIterator
+    : public GlyphLoadIterator
   {
   public:
 
 
     GlyphLoadIteratorNaive( FT_Long  num_load_glyphs )
       : GlyphLoadIterator( num_load_glyphs ) {}
-
-
-    GlyphLoadIteratorNaive(
-      const GlyphLoadIteratorNaive& ) = delete;
-    GlyphLoadIteratorNaive& operator= (
-      const GlyphLoadIteratorNaive& ) = delete;
-
-
-    virtual
-    ~GlyphLoadIteratorNaive( void ) {}
 
 
     void
@@ -52,6 +42,7 @@
 
     bool  last_load_successful = false;
   };
+}
 
 
 #endif // ITERATORS_GLYPH_LOAD_ITERATOR_NAIVE_H_

--- a/fuzzing/src/iterators/glyphloaditerator.cpp
+++ b/fuzzing/src/iterators/glyphloaditerator.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphLoadIterator.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -17,7 +17,7 @@
 #include "utils/logging.h"
 
 
-  GlyphLoadIterator::
+  freetype::GlyphLoadIterator::
   GlyphLoadIterator( FT_Long  num_load_glyphs )
   {
     (void) set_num_load_glyphs( num_load_glyphs );
@@ -25,7 +25,7 @@
 
 
   void
-  GlyphLoadIterator::
+  freetype::GlyphLoadIterator::
   set_num_load_glyphs( FT_Long  glyphs )
   {
     num_load_glyphs = glyphs;
@@ -34,7 +34,7 @@
 
 
   void
-  GlyphLoadIterator::
+  freetype::GlyphLoadIterator::
   add_load_flags( FT_Int32  flags )
   {
     load_flags |= flags;
@@ -42,23 +42,23 @@
 
 
   void
-  GlyphLoadIterator::
-  add_visitor( unique_ptr<GlyphVisitor>  visitor )
+  freetype::GlyphLoadIterator::
+  add_visitor( std::unique_ptr<GlyphVisitor>  visitor )
   {
     (void) glyph_visitors.emplace_back( move( visitor ) );
   }
 
 
   void
-  GlyphLoadIterator::
-  add_iterator( unique_ptr<GlyphRenderIterator>  iterator )
+  freetype::GlyphLoadIterator::
+  add_iterator( std::unique_ptr<GlyphRenderIterator>  iterator )
   {
     (void) glyph_render_iterators.emplace_back( move( iterator ) );
   }
 
 
   void
-  GlyphLoadIterator::
+  freetype::GlyphLoadIterator::
   invoke_visitors_and_iterators( const Unique_FT_Glyph&  glyph )
   {
     Unique_FT_Glyph  buffer_glyph = make_unique_glyph();

--- a/fuzzing/src/iterators/glyphloaditerator.h
+++ b/fuzzing/src/iterators/glyphloaditerator.h
@@ -2,7 +2,7 @@
 //
 //   Base class of iterators over glyphs.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,22 +15,23 @@
 #ifndef ITERATORS_GLYPH_LOAD_ITERATOR_H_
 #define ITERATORS_GLYPH_LOAD_ITERATOR_H_
 
+#include <memory> // std::unique_ptr
 #include <vector>
+
+#include <boost/core/noncopyable.hpp>
 
 #include "iterators/glyphrenderiterator.h"
 #include "utils/utils.h"
 #include "visitors/glyphvisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class GlyphLoadIterator
+    : private boost::noncopyable
   {
   public:
-
-
-    GlyphLoadIterator( void ) {}
 
 
     // @See: `GlyphLoadIterator::set_num_load_glyphs()'.
@@ -38,12 +39,8 @@
     GlyphLoadIterator( FT_Long  num_load_glyphs );
 
 
-    GlyphLoadIterator( const GlyphLoadIterator& ) = delete;
-    GlyphLoadIterator& operator= ( const GlyphLoadIterator& ) = delete;
-
-
     virtual
-    ~GlyphLoadIterator( void ) {}
+    ~GlyphLoadIterator() = default;
 
 
     virtual void
@@ -78,7 +75,7 @@
     //   A reference to the added visitor.
 
     void
-    add_visitor( unique_ptr<GlyphVisitor>  visitor );
+    add_visitor( std::unique_ptr<GlyphVisitor>  visitor );
 
 
     // @Description:
@@ -92,18 +89,17 @@
     //   A reference to the added iterator.
 
     void
-    add_iterator( unique_ptr<GlyphRenderIterator>  iterator );
+    add_iterator( std::unique_ptr<GlyphRenderIterator>  iterator );
 
     
   protected:
 
 
-    FT_Long  num_load_glyphs = -1;
+    FT_Long   num_load_glyphs = -1;
+    FT_Int32  load_flags      = FT_LOAD_DEFAULT;
 
-    FT_Int32  load_flags = FT_LOAD_DEFAULT;
-
-    vector<unique_ptr<GlyphVisitor>>         glyph_visitors;
-    vector<unique_ptr<GlyphRenderIterator>>  glyph_render_iterators;
+    std::vector<std::unique_ptr<GlyphVisitor>>         glyph_visitors;
+    std::vector<std::unique_ptr<GlyphRenderIterator>>  glyph_render_iterators;
 
 
     // @Description:
@@ -117,6 +113,7 @@
     void
     invoke_visitors_and_iterators( const Unique_FT_Glyph&  glyph );
   };
+}
 
 
 #endif // ITERATORS_GLYPH_LOAD_ITERATOR_H_

--- a/fuzzing/src/iterators/glyphrenderiterator-allmodes.cpp
+++ b/fuzzing/src/iterators/glyphrenderiterator-allmodes.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphRenderIteratorAllModes.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,7 +23,7 @@
 
 
   void
-  GlyphRenderIteratorAllModes::
+  freetype::GlyphRenderIteratorAllModes::
   run( Unique_FT_Glyph  glyph )
   {
     FT_Error  error;

--- a/fuzzing/src/iterators/glyphrenderiterator-allmodes.h
+++ b/fuzzing/src/iterators/glyphrenderiterator-allmodes.h
@@ -7,7 +7,7 @@
 //     - lcd
 //     - lcd v
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -24,32 +24,19 @@
 #include "iterators/glyphloaditerator.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class GlyphRenderIteratorAllModes
-  : public GlyphRenderIterator
+    : public GlyphRenderIterator
   {
   public:
-
-
-    GlyphRenderIteratorAllModes( void ) {}
-    
-
-    GlyphRenderIteratorAllModes(
-      const GlyphRenderIteratorAllModes& ) = delete;
-    GlyphRenderIteratorAllModes& operator= (
-      const GlyphRenderIteratorAllModes& ) = delete;
-
-
-    virtual
-    ~GlyphRenderIteratorAllModes( void ) {}
 
 
     void
     run( Unique_FT_Glyph  glyph )
     override;
   };
-
+}
 
 #endif // ITERATORS_GLYPH_RENDER_ITERATOR_ALL_MODES_H_

--- a/fuzzing/src/iterators/glyphrenderiterator.cpp
+++ b/fuzzing/src/iterators/glyphrenderiterator.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphRenderIterator.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,10 +14,12 @@
 
 #include "iterators/glyphrenderiterator.h"
 
+#include <utility> // std::move
+
 
   void
-  GlyphRenderIterator::
-  add_visitor( unique_ptr<GlyphVisitor>  visitor )
+  freetype::GlyphRenderIterator::
+  add_visitor( std::unique_ptr<GlyphVisitor>  visitor )
   {
-    (void) glyph_visitors.emplace_back( move( visitor ) );
+    (void) glyph_visitors.emplace_back( std::move( visitor ) );
   }

--- a/fuzzing/src/iterators/glyphrenderiterator.h
+++ b/fuzzing/src/iterators/glyphrenderiterator.h
@@ -2,7 +2,7 @@
 //
 //   Base class of iterators that render glyphs.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -16,29 +16,26 @@
 #define ITERATORS_GLYPH_RENDER_ITERATOR_H_
 
 
+#include <memory> // std::unique_ptr
 #include <vector>
+
+#include <boost/core/noncopyable.hpp>
 
 #include "utils/utils.h"
 #include "visitors/glyphvisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class GlyphRenderIterator
+    : private boost::noncopyable
   {
   public:
 
 
-    GlyphRenderIterator( void ) {}
-
-
-    GlyphRenderIterator( const GlyphRenderIterator& ) = delete;
-    GlyphRenderIterator& operator= ( const GlyphRenderIterator& ) = delete;
-
-
     virtual
-    ~GlyphRenderIterator( void ) {}
+    ~GlyphRenderIterator() = default;
 
 
     virtual void
@@ -53,14 +50,18 @@
     //     A glyph visitor.
 
     void
-    add_visitor( unique_ptr<GlyphVisitor>  visitor );
+    add_visitor( std::unique_ptr<GlyphVisitor>  visitor );
 
     
   protected:
 
 
-    vector<unique_ptr<GlyphVisitor>>  glyph_visitors;
+    typedef std::vector<std::unique_ptr<GlyphVisitor>>  GlyphVisitors;
+
+
+    GlyphVisitors  glyph_visitors;
   };
+}
 
 
 #endif // ITERATORS_GLYPH_RENDER_ITERATOR_H_

--- a/fuzzing/src/targets/FaceFuzzTarget.cpp
+++ b/fuzzing/src/targets/FaceFuzzTarget.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceFuzzTarget.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,14 +23,17 @@
 
 
   const FT_UInt
-  FaceFuzzTarget::HINTING_ADOBE    = FT_HINTING_ADOBE;
+  freetype::FaceFuzzTarget::
+  HINTING_ADOBE = FT_HINTING_ADOBE;
+
 
   const FT_UInt
-  FaceFuzzTarget::HINTING_FREETYPE = FT_HINTING_FREETYPE;
+  freetype::FaceFuzzTarget::
+  HINTING_FREETYPE = FT_HINTING_FREETYPE;
 
 
   void
-  FaceFuzzTarget::
+  freetype::FaceFuzzTarget::
   run( const uint8_t*  data,
        size_t          size )
   {
@@ -46,7 +49,7 @@
 
 
   void
-  FaceFuzzTarget::
+  freetype::FaceFuzzTarget::
   set_supported_font_format( FaceLoader::FontFormat  format )
   {
     assert( face_load_iterator != nullptr );
@@ -55,7 +58,7 @@
 
 
   void
-  FaceFuzzTarget::
+  freetype::FaceFuzzTarget::
   set_data_is_tar_archive( bool  is_tar_archive )
   {
     assert( face_load_iterator != nullptr );
@@ -64,10 +67,10 @@
 
 
   bool
-  FaceFuzzTarget::
-  set_property( const string  module_name,
-                const string  property_name,
-                const void*   value )
+  freetype::FaceFuzzTarget::
+  set_property( const std::string  module_name,
+                const std::string  property_name,
+                const void*        value )
   {
     FT_Error  error;
 
@@ -86,9 +89,9 @@
   }
 
 
-  unique_ptr<FaceLoadIterator>&
-  FaceFuzzTarget::
-  set_iterator( unique_ptr<FaceLoadIterator>  iterator )
+  std::unique_ptr<freetype::FaceLoadIterator>&
+  freetype::FaceFuzzTarget::
+  set_iterator( std::unique_ptr<FaceLoadIterator>  iterator )
   {
     face_load_iterator = move( iterator );
     return face_load_iterator;

--- a/fuzzing/src/targets/FaceFuzzTarget.h
+++ b/fuzzing/src/targets/FaceFuzzTarget.h
@@ -2,7 +2,7 @@
 //
 //   Base class of face fuzz targets.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -31,11 +31,11 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceFuzzTarget
-    : public freetype::FuzzTarget
+    : public FuzzTarget
   {
   public:
 
@@ -90,9 +90,9 @@
     //   `false' if `FT_Property_Set' returns an error, 'true' otherwise.
 
     bool
-    set_property( const string  module_name,
-                  const string  property_name,
-                  const void*   value );
+    set_property( const std::string  module_name,
+                  const std::string  property_name,
+                  const void*        value );
 
 
     // @Description:
@@ -105,9 +105,9 @@
     //
     // @Return:
     //   A reference to the added iterator.
-    
-    unique_ptr<FaceLoadIterator>&
-    set_iterator( unique_ptr<FaceLoadIterator>  iterator );
+
+    std::unique_ptr<FaceLoadIterator>&
+    set_iterator( std::unique_ptr<FaceLoadIterator>  iterator );
 
 
   protected:
@@ -120,8 +120,9 @@
   private:
 
 
-    unique_ptr<FaceLoadIterator>  face_load_iterator;
+    std::unique_ptr<FaceLoadIterator>  face_load_iterator;
   };
+}
 
 
 #endif // TARGETS_FACEFUZZTARGET_H_

--- a/fuzzing/src/targets/FuzzTarget.cpp
+++ b/fuzzing/src/targets/FuzzTarget.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FuzzTarget.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,

--- a/fuzzing/src/targets/FuzzTarget.h
+++ b/fuzzing/src/targets/FuzzTarget.h
@@ -2,7 +2,7 @@
 //
 //   Base class of fuzz targets.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -18,6 +18,8 @@
 
 #include <cstdint>
 
+#include <boost/core/noncopyable.hpp>
+
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include <freetype/internal/internal.h>
@@ -26,15 +28,14 @@
 
 namespace freetype {
 
+
   class FuzzTarget
+    : private boost::noncopyable
   {
   public:
 
 
-    FuzzTarget( const FuzzTarget& ) = delete;
-    FuzzTarget& operator= ( const FuzzTarget& ) = delete;
-
-
+    virtual
     ~FuzzTarget();
 
 

--- a/fuzzing/src/targets/font-drivers/bdf-render.cpp
+++ b/fuzzing/src/targets/font-drivers/bdf-render.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of BdfRenderFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,36 +14,35 @@
 
 #include "targets/font-drivers/bdf-render.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "visitors/facevisitor-loadglyphs-bitmaps.h"
 
 
-  using namespace std;
-
-
-  BdfRenderFuzzTarget::
-  BdfRenderFuzzTarget( void )
+  freetype::BdfRenderFuzzTarget::
+  BdfRenderFuzzTarget()
   {
-    auto  fli          = fuzzing::make_unique<FaceLoadIterator>();
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
+    auto  fli          = freetype::make_unique<FaceLoadIterator>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterator:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
 
     // -----------------------------------------------------------------------
     // Face load iterator:
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::BDF );
     
-    (void) fli->add_iterator( move( fpi_bitmaps ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps ) );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/bdf-render.h
+++ b/fuzzing/src/targets/font-drivers/bdf-render.h
@@ -2,7 +2,7 @@
 //
 //   Render BDF faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class BdfRenderFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    BdfRenderFuzzTarget( void );
+    BdfRenderFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_BDF_RENDER_H_

--- a/fuzzing/src/targets/font-drivers/bdf.cpp
+++ b/fuzzing/src/targets/font-drivers/bdf.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of BdfFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,6 +14,8 @@
 
 #include "targets/font-drivers/bdf.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "visitors/facevisitor-bdf.h"
@@ -21,14 +23,11 @@
 #include "visitors/facevisitor-variants.h"
 
 
-  using namespace std;
-
-
-  BdfFuzzTarget::
-  BdfFuzzTarget( void )
+  freetype::BdfFuzzTarget::
+  BdfFuzzTarget()
   {
-    auto  fli          = fuzzing::make_unique<FaceLoadIterator>();
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
+    auto  fli          = freetype::make_unique<FaceLoadIterator>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
 
 
     // -----------------------------------------------------------------------
@@ -36,19 +35,19 @@
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::BDF );
     
-    (void) fli->add_iterator( move( fpi_bitmaps ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps ) );
     
     (void) fli
       ->add_once_visitor(
-        fuzzing::make_unique<FaceVisitorBdf>(
+        freetype::make_unique<FaceVisitorBdf>(
           FaceLoader::FontFormat::BDF ) );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorCharCodes>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorCharCodes>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorVariants>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorVariants>() );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/bdf.h
+++ b/fuzzing/src/targets/font-drivers/bdf.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz BDF faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class BdfFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    BdfFuzzTarget( void );
+    BdfFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_BDF_H_

--- a/fuzzing/src/targets/font-drivers/cff-ftengine.cpp
+++ b/fuzzing/src/targets/font-drivers/cff-ftengine.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of CffFtEngineFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/cff-ftengine.h"
 
 
-  CffFtEngineFuzzTarget::
-  CffFtEngineFuzzTarget( void )
+  freetype::CffFtEngineFuzzTarget::
+  CffFtEngineFuzzTarget()
   {
     (void) set_property( "cff", "hinting-engine", &HINTING_FREETYPE );
   }

--- a/fuzzing/src/targets/font-drivers/cff-ftengine.h
+++ b/fuzzing/src/targets/font-drivers/cff-ftengine.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz CFF faces using FreeType's hinting engine.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/cff.h"
 
 
+namespace freetype {
+
+
   class CffFtEngineFuzzTarget
     : public CffFuzzTarget
   {
   public:
 
 
-    CffFtEngineFuzzTarget( void );
+    CffFtEngineFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_CFF_FT_ENGINE_H_

--- a/fuzzing/src/targets/font-drivers/cff-render-ftengine.cpp
+++ b/fuzzing/src/targets/font-drivers/cff-render-ftengine.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of CffRenderFtEngineFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/cff-render-ftengine.h"
 
 
-  CffRenderFtEngineFuzzTarget::
-  CffRenderFtEngineFuzzTarget( void )
+  freetype::CffRenderFtEngineFuzzTarget::
+  CffRenderFtEngineFuzzTarget()
   {
     (void) set_property( "cff", "hinting-engine", &HINTING_FREETYPE );
   }

--- a/fuzzing/src/targets/font-drivers/cff-render-ftengine.h
+++ b/fuzzing/src/targets/font-drivers/cff-render-ftengine.h
@@ -2,7 +2,7 @@
 //
 //   Render CFF fonts using FreeType's hinting engine.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/cff-render.h"
 
 
+namespace freetype {
+
+
   class CffRenderFtEngineFuzzTarget
     : public CffRenderFuzzTarget
   {
   public:
 
 
-    CffRenderFtEngineFuzzTarget( void );
+    CffRenderFtEngineFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_CFF_RENDER_FT_ENGINE_H_

--- a/fuzzing/src/targets/font-drivers/cff-render.cpp
+++ b/fuzzing/src/targets/font-drivers/cff-render.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of CffRenderFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -13,6 +13,8 @@
 
 
 #include "targets/font-drivers/cff-render.h"
+
+#include <utility> // std::move
 
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
@@ -25,57 +27,54 @@
 #include "visitors/facevisitor-subglyphs.h"
 
 
-  using namespace std;
-
-
-  CffRenderFuzzTarget::
-  CffRenderFuzzTarget( void )
+  freetype::CffRenderFuzzTarget::
+  CffRenderFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
     auto  fpi_mm =
-      fuzzing::make_unique<FacePrepIteratorMultipleMasters>();
+      freetype::make_unique<FacePrepIteratorMultipleMasters>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterators:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
 
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsOutlines>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorRenderGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorRenderGlyphs>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorSubGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorSubGlyphs>() );
 
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsOutlines>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorRenderGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorRenderGlyphs>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorSubGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorSubGlyphs>() );
 
     // -----------------------------------------------------------------------
     // Face load iterators:
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::CFF );
-    
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
-    (void) fli->add_iterator( move( fpi_mm       ) );
+
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_mm       ) );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
     (void) set_property( "cff", "hinting-engine", &HINTING_ADOBE );
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/cff-render.h
+++ b/fuzzing/src/targets/font-drivers/cff-render.h
@@ -2,7 +2,7 @@
 //
 //   Render CFF faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class CffRenderFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    CffRenderFuzzTarget( void );
+    CffRenderFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_CFF_RENDER_H_

--- a/fuzzing/src/targets/font-drivers/cff.cpp
+++ b/fuzzing/src/targets/font-drivers/cff.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of CffFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -13,6 +13,8 @@
 
 
 #include "targets/font-drivers/cff.h"
+
+#include <utility> // std::move
 
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
@@ -29,63 +31,60 @@
 #include "visitors/facevisitor-variants.h"
 
 
-  using namespace std;
-
-
-  CffFuzzTarget::
-  CffFuzzTarget( void )
+  freetype::CffFuzzTarget::
+  CffFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
     auto  fpi_mm =
-      fuzzing::make_unique<FacePrepIteratorMultipleMasters>();
+      freetype::make_unique<FacePrepIteratorMultipleMasters>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterators:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorKerning>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorKerning>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorKerning>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorKerning>() );
 
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorMultipleMasters>(
+      ->add_visitor( freetype::make_unique<FaceVisitorMultipleMasters>(
                        FaceLoader::FontFormat::CFF ) );
 
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorType1Tables>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorType1Tables>() );
 
     // -----------------------------------------------------------------------
     // Face load iterators:
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::CFF );
-    
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
-    (void) fli->add_iterator( move( fpi_mm       ) );
-    
-    (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorCharCodes>() );
-    (void) fli->add_once_visitor( fuzzing::make_unique<FaceVisitorCid>() );
-    (void) fli->add_once_visitor( fuzzing::make_unique<FaceVisitorGasp>() );
-    (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorSfntNames>() );
-    (void) fli
-      ->add_once_visitor(
-        fuzzing::make_unique<FaceVisitorTrueTypeTables>() );
-    (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorVariants>() );
+
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_mm       ) );
 
     (void) fli
-      ->add_always_visitor( fuzzing::make_unique<FaceVisitorType1Tables>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorCharCodes>() );
+    (void) fli->add_once_visitor( freetype::make_unique<FaceVisitorCid>() );
+    (void) fli->add_once_visitor( freetype::make_unique<FaceVisitorGasp>() );
+    (void) fli
+      ->add_once_visitor( freetype::make_unique<FaceVisitorSfntNames>() );
+    (void) fli
+      ->add_once_visitor(
+        freetype::make_unique<FaceVisitorTrueTypeTables>() );
+    (void) fli
+      ->add_once_visitor( freetype::make_unique<FaceVisitorVariants>() );
+
+    (void) fli
+      ->add_always_visitor( freetype::make_unique<FaceVisitorType1Tables>() );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
     (void) set_property( "cff", "hinting-engine", &HINTING_ADOBE );
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/cff.h
+++ b/fuzzing/src/targets/font-drivers/cff.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz CFF faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class CffFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    CffFuzzTarget( void );
+    CffFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_CFF_H_

--- a/fuzzing/src/targets/font-drivers/cidtype1-ftengine.cpp
+++ b/fuzzing/src/targets/font-drivers/cidtype1-ftengine.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of CidType1FtEngineFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/cidtype1-ftengine.h"
 
 
-  CidType1FtEngineFuzzTarget::
-  CidType1FtEngineFuzzTarget( void )
+  freetype::CidType1FtEngineFuzzTarget::
+  CidType1FtEngineFuzzTarget()
   {
     (void) set_property( "t1cid", "hinting-engine", &HINTING_FREETYPE );
   }

--- a/fuzzing/src/targets/font-drivers/cidtype1-ftengine.h
+++ b/fuzzing/src/targets/font-drivers/cidtype1-ftengine.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for CID Type 1 fonts using FreeType's hinting engine.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/cidtype1.h"
 
 
+namespace freetype {
+
+
   class CidType1FtEngineFuzzTarget
     : public CidType1FuzzTarget
   {
   public:
 
 
-    CidType1FtEngineFuzzTarget( void );
+    CidType1FtEngineFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_CID_TYPE_1_FT_ENGINE_H_

--- a/fuzzing/src/targets/font-drivers/cidtype1-render-ftengine.cpp
+++ b/fuzzing/src/targets/font-drivers/cidtype1-render-ftengine.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of CidType1RenderFtEngineFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/cidtype1-render-ftengine.h"
 
 
-  CidType1RenderFtEngineFuzzTarget::
-  CidType1RenderFtEngineFuzzTarget( void )
+  freetype::CidType1RenderFtEngineFuzzTarget::
+  CidType1RenderFtEngineFuzzTarget()
   {
     (void) set_property( "t1cid", "hinting-engine", &HINTING_FREETYPE );
   }

--- a/fuzzing/src/targets/font-drivers/cidtype1-render-ftengine.h
+++ b/fuzzing/src/targets/font-drivers/cidtype1-render-ftengine.h
@@ -2,7 +2,7 @@
 //
 //   Rendering CID Type 1 faces with FreeType's hinting engine.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/cidtype1-render.h"
 
 
+namespace freetype {
+
+
   class CidType1RenderFtEngineFuzzTarget
     : public CidType1RenderFuzzTarget
   {
   public:
 
 
-    CidType1RenderFtEngineFuzzTarget( void );
+    CidType1RenderFtEngineFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_CID_TYPE_1_RENDER_FT_ENGINE_H_

--- a/fuzzing/src/targets/font-drivers/cidtype1-render.cpp
+++ b/fuzzing/src/targets/font-drivers/cidtype1-render.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of CidType1RenderFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,6 +14,8 @@
 
 #include "targets/font-drivers/cidtype1-render.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "iterators/faceprepiterator-outlines.h"
@@ -24,32 +26,29 @@
 #include "visitors/facevisitor-subglyphs.h"
 
 
-  using namespace std;
-
-
-  CidType1RenderFuzzTarget::
-  CidType1RenderFuzzTarget( void )
+  freetype::CidType1RenderFuzzTarget::
+  CidType1RenderFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterators:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
 
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsOutlines>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorRenderGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorRenderGlyphs>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorSubGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorSubGlyphs>() );
 
     // -----------------------------------------------------------------------
     // Face load iterators:
@@ -57,13 +56,13 @@
     (void) fli
       ->set_supported_font_format( FaceLoader::FontFormat::CID_TYPE_1 );
 
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
     (void) set_property( "t1cid", "hinting-engine", &HINTING_ADOBE );
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/cidtype1-render.h
+++ b/fuzzing/src/targets/font-drivers/cidtype1-render.h
@@ -2,7 +2,7 @@
 //
 //   Render CID Type 1 faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class CidType1RenderFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    CidType1RenderFuzzTarget( void );
+    CidType1RenderFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_CID_TYPE_1_RENDER_H_

--- a/fuzzing/src/targets/font-drivers/cidtype1.cpp
+++ b/fuzzing/src/targets/font-drivers/cidtype1.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of CidType1FuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,6 +14,8 @@
 
 #include "targets/font-drivers/cidtype1.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "iterators/faceprepiterator-outlines.h"
@@ -23,16 +25,13 @@
 #include "visitors/facevisitor-variants.h"
 
 
-  using namespace std;
-
-
-  CidType1FuzzTarget::
-  CidType1FuzzTarget( void )
+  freetype::CidType1FuzzTarget::
+  CidType1FuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
 
 
     // -----------------------------------------------------------------------
@@ -41,22 +40,22 @@
     (void) fli
       ->set_supported_font_format( FaceLoader::FontFormat::CID_TYPE_1 );
 
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
 
-    (void) fli->add_once_visitor( fuzzing::make_unique<FaceVisitorCid>() );
+    (void) fli->add_once_visitor( freetype::make_unique<FaceVisitorCid>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorCharCodes>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorCharCodes>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorVariants>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorVariants>() );
 
     (void) fli
-      ->add_always_visitor( fuzzing::make_unique<FaceVisitorType1Tables>() );
+      ->add_always_visitor( freetype::make_unique<FaceVisitorType1Tables>() );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
     (void) set_property( "t1cid", "hinting-engine", &HINTING_ADOBE );
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/cidtype1.h
+++ b/fuzzing/src/targets/font-drivers/cidtype1.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for CID Type 1 fonts using Adobe's hinting engine.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class CidType1FuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    CidType1FuzzTarget( void );
+    CidType1FuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_CID_TYPE_1_H_

--- a/fuzzing/src/targets/font-drivers/pcf-render.cpp
+++ b/fuzzing/src/targets/font-drivers/pcf-render.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of PcfRenderFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,36 +14,35 @@
 
 #include "targets/font-drivers/pcf-render.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "visitors/facevisitor-loadglyphs-bitmaps.h"
 
 
-  using namespace std;
-
-
-  PcfRenderFuzzTarget::
-  PcfRenderFuzzTarget( void )
+  freetype::PcfRenderFuzzTarget::
+  PcfRenderFuzzTarget()
   {
-    auto  fli          = fuzzing::make_unique<FaceLoadIterator>();
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
+    auto  fli          = freetype::make_unique<FaceLoadIterator>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterator:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
 
     // -----------------------------------------------------------------------
     // Face load iterator:
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::PCF );
     
-    (void) fli->add_iterator( move( fpi_bitmaps ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps ) );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/pcf-render.h
+++ b/fuzzing/src/targets/font-drivers/pcf-render.h
@@ -2,7 +2,7 @@
 //
 //   Render PCF faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class PcfRenderFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    PcfRenderFuzzTarget( void );
+    PcfRenderFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_PCF_RENDER_H_

--- a/fuzzing/src/targets/font-drivers/pcf.cpp
+++ b/fuzzing/src/targets/font-drivers/pcf.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of PcfFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,6 +14,8 @@
 
 #include "targets/font-drivers/pcf.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "visitors/facevisitor-bdf.h"
@@ -21,14 +23,11 @@
 #include "visitors/facevisitor-variants.h"
 
 
-  using namespace std;
-
-
-  PcfFuzzTarget::
-  PcfFuzzTarget( void )
+  freetype::PcfFuzzTarget::
+  PcfFuzzTarget()
   {
-    auto  fli          = fuzzing::make_unique<FaceLoadIterator>();
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
+    auto  fli          = freetype::make_unique<FaceLoadIterator>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
 
 
     // -----------------------------------------------------------------------
@@ -36,19 +35,19 @@
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::PCF );
     
-    (void) fli->add_iterator( move( fpi_bitmaps ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps ) );
     
     (void) fli
       ->add_once_visitor(
-        fuzzing::make_unique<FaceVisitorBdf>(
+        freetype::make_unique<FaceVisitorBdf>(
           FaceLoader::FontFormat::PCF ) );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorCharCodes>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorCharCodes>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorVariants>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorVariants>() );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/pcf.h
+++ b/fuzzing/src/targets/font-drivers/pcf.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz PCF faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class PcfFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    PcfFuzzTarget( void );
+    PcfFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_PCF_H_

--- a/fuzzing/src/targets/font-drivers/truetype-render-i35.cpp
+++ b/fuzzing/src/targets/font-drivers/truetype-render-i35.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of TrueTypeRenderI35FuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/truetype-render-i35.h"
 
 
-  TrueTypeRenderI35FuzzTarget::
-  TrueTypeRenderI35FuzzTarget( void )
+  freetype::TrueTypeRenderI35FuzzTarget::
+  TrueTypeRenderI35FuzzTarget()
   {
     (void) set_property( "truetype",
                          "interpreter-version",

--- a/fuzzing/src/targets/font-drivers/truetype-render-i35.h
+++ b/fuzzing/src/targets/font-drivers/truetype-render-i35.h
@@ -2,7 +2,7 @@
 //
 //   Render TrueType faces using interpreter version 35.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/truetype-render.h"
 
 
+namespace freetype {
+
+
   class TrueTypeRenderI35FuzzTarget
     : public TrueTypeRenderFuzzTarget
   {
   public:
 
 
-    TrueTypeRenderI35FuzzTarget( void );
+    TrueTypeRenderI35FuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TRUETYPE_RENDER_I35_H_

--- a/fuzzing/src/targets/font-drivers/truetype-render-i38.cpp
+++ b/fuzzing/src/targets/font-drivers/truetype-render-i38.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of TrueTypeRenderI38FuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/truetype-render-i38.h"
 
 
-  TrueTypeRenderI38FuzzTarget::
-  TrueTypeRenderI38FuzzTarget( void )
+  freetype::TrueTypeRenderI38FuzzTarget::
+  TrueTypeRenderI38FuzzTarget()
   {
     (void) set_property( "truetype",
                          "interpreter-version",

--- a/fuzzing/src/targets/font-drivers/truetype-render-i38.h
+++ b/fuzzing/src/targets/font-drivers/truetype-render-i38.h
@@ -2,7 +2,7 @@
 //
 //   Render TrueType faces using interpreter version 38.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/truetype-render.h"
 
 
+namespace freetype {
+
+
   class TrueTypeRenderI38FuzzTarget
     : public TrueTypeRenderFuzzTarget
   {
   public:
 
 
-    TrueTypeRenderI38FuzzTarget( void );
+    TrueTypeRenderI38FuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TRUETYPE_RENDER_I38_H_

--- a/fuzzing/src/targets/font-drivers/truetype-render.cpp
+++ b/fuzzing/src/targets/font-drivers/truetype-render.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of TrueTypeRenderFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -13,6 +13,8 @@
 
 
 #include "targets/font-drivers/truetype-render.h"
+
+#include <utility> // std::move
 
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
@@ -26,60 +28,64 @@
 #include "utils/logging.h"
 
 
-  using namespace std;
+  const FT_UInt
+  freetype::TrueTypeRenderFuzzTarget::
+  INTERPRETER_VERSION_35 = TT_INTERPRETER_VERSION_35;
 
 
-  const FT_UInt  TrueTypeRenderFuzzTarget::INTERPRETER_VERSION_35 =
-    TT_INTERPRETER_VERSION_35;
-  const FT_UInt  TrueTypeRenderFuzzTarget::INTERPRETER_VERSION_38 =
-    TT_INTERPRETER_VERSION_38;
-  const FT_UInt  TrueTypeRenderFuzzTarget::INTERPRETER_VERSION_40 =
-    TT_INTERPRETER_VERSION_40;
+  const FT_UInt
+  freetype::TrueTypeRenderFuzzTarget::
+  INTERPRETER_VERSION_38 = TT_INTERPRETER_VERSION_38;
 
 
-  TrueTypeRenderFuzzTarget::
-  TrueTypeRenderFuzzTarget( void )
+  const FT_UInt
+  freetype::TrueTypeRenderFuzzTarget::
+  INTERPRETER_VERSION_40 = TT_INTERPRETER_VERSION_40;
+
+
+  freetype::TrueTypeRenderFuzzTarget::
+  TrueTypeRenderFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
     auto  fpi_mm =
-      fuzzing::make_unique<FacePrepIteratorMultipleMasters>();
+      freetype::make_unique<FacePrepIteratorMultipleMasters>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterators:
     
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
 
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsOutlines>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorRenderGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorRenderGlyphs>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorSubGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorSubGlyphs>() );
 
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsOutlines>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorRenderGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorRenderGlyphs>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorSubGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorSubGlyphs>() );
 
     // -----------------------------------------------------------------------
     // Face load iterators:
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::TRUETYPE );
 
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
-    (void) fli->add_iterator( move( fpi_mm       ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_mm       ) );
     
     // -----------------------------------------------------------------------
     // Fuzz target:
@@ -88,5 +94,5 @@
                          "interpreter-version",
                          &INTERPRETER_VERSION_40 );
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/truetype-render.h
+++ b/fuzzing/src/targets/font-drivers/truetype-render.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for rendering TrueType faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,13 +22,16 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class TrueTypeRenderFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    TrueTypeRenderFuzzTarget( void );
+    TrueTypeRenderFuzzTarget();
 
 
   protected:
@@ -41,6 +44,7 @@
     static const FT_UInt  INTERPRETER_VERSION_38;
     static const FT_UInt  INTERPRETER_VERSION_40;
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TRUETYPE_RENDER_H_

--- a/fuzzing/src/targets/font-drivers/truetype.cpp
+++ b/fuzzing/src/targets/font-drivers/truetype.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of TrueTypeFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -13,6 +13,8 @@
 
 
 #include "targets/font-drivers/truetype.h"
+
+#include <utility> // std::move
 
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
@@ -28,38 +30,35 @@
 #include "visitors/facevisitor-variants.h"
 
 
-  using namespace std;
-
-
-  TrueTypeFuzzTarget::
-  TrueTypeFuzzTarget( void )
+  freetype::TrueTypeFuzzTarget::
+  TrueTypeFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
     auto  fpi_mm =
-      fuzzing::make_unique<FacePrepIteratorMultipleMasters>();
+      freetype::make_unique<FacePrepIteratorMultipleMasters>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterators:
     
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorKerning>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorKerning>() );
 
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorKerning>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorKerning>() );
     (void) fpi_outlines
       ->add_visitor(
-        fuzzing::make_unique<FaceVisitorMultipleMasters>(
+        freetype::make_unique<FaceVisitorMultipleMasters>(
           FaceLoader::FontFormat::TRUETYPE ) );
 
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorKerning>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorKerning>() );
     (void) fpi_mm
       ->add_visitor(
-        fuzzing::make_unique<FaceVisitorMultipleMasters>(
+        freetype::make_unique<FaceVisitorMultipleMasters>(
           FaceLoader::FontFormat::TRUETYPE ) );
 
     // -----------------------------------------------------------------------
@@ -67,27 +66,27 @@
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::TRUETYPE );
 
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
-    (void) fli->add_iterator( move( fpi_mm       ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_mm       ) );
 
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorCharCodes>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorCharCodes>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorGasp>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorGasp>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorSfntNames>() );
-    (void) fli
-      ->add_once_visitor(
-        fuzzing::make_unique<FaceVisitorTrueTypePatents>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorSfntNames>() );
     (void) fli
       ->add_once_visitor(
-        fuzzing::make_unique<FaceVisitorTrueTypeTables>() );
+        freetype::make_unique<FaceVisitorTrueTypePatents>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorVariants>() );
+      ->add_once_visitor(
+        freetype::make_unique<FaceVisitorTrueTypeTables>() );
+    (void) fli
+      ->add_once_visitor( freetype::make_unique<FaceVisitorVariants>() );
     
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/truetype.h
+++ b/fuzzing/src/targets/font-drivers/truetype.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for TrueType faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class TrueTypeFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    TrueTypeFuzzTarget( void );
+    TrueTypeFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TRUETYPE_H_

--- a/fuzzing/src/targets/font-drivers/type1-ftengine.cpp
+++ b/fuzzing/src/targets/font-drivers/type1-ftengine.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of Type1FtEngineFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/type1-ftengine.h"
 
 
-  Type1FtEngineFuzzTarget::
-  Type1FtEngineFuzzTarget( void )
+  freetype::Type1FtEngineFuzzTarget::
+  Type1FtEngineFuzzTarget()
   {
     (void) set_property( "type1", "hinting-engine", &HINTING_FREETYPE );
   }

--- a/fuzzing/src/targets/font-drivers/type1-ftengine.h
+++ b/fuzzing/src/targets/font-drivers/type1-ftengine.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz Type 1 faces using FreeType's hinting engine.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/type1.h"
 
 
+namespace freetype {
+
+
   class Type1FtEngineFuzzTarget
     : public Type1FuzzTarget
   {
   public:
 
 
-    Type1FtEngineFuzzTarget( void );
+    Type1FtEngineFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TYPE_1_FT_ENGINE_H_

--- a/fuzzing/src/targets/font-drivers/type1-render-ftengine.cpp
+++ b/fuzzing/src/targets/font-drivers/type1-render-ftengine.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of Type1RenderFtEngineFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/type1-render-ftengine.h"
 
 
-  Type1RenderFtEngineFuzzTarget::
-  Type1RenderFtEngineFuzzTarget( void )
+  freetype::Type1RenderFtEngineFuzzTarget::
+  Type1RenderFtEngineFuzzTarget()
   {
     (void) set_property( "type1", "hinting-engine", &HINTING_FREETYPE );
   }

--- a/fuzzing/src/targets/font-drivers/type1-render-ftengine.h
+++ b/fuzzing/src/targets/font-drivers/type1-render-ftengine.h
@@ -2,7 +2,7 @@
 //
 //   Render Type 1 faces using FreeType's hinting engine.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/type1-render.h"
 
 
+namespace freetype {
+
+
   class Type1RenderFtEngineFuzzTarget
     : public Type1RenderFuzzTarget
   {
   public:
 
 
-    Type1RenderFtEngineFuzzTarget( void );
+    Type1RenderFtEngineFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TYPE_1_RENDER_FT_ENGINE_H_

--- a/fuzzing/src/targets/font-drivers/type1-render-tar.cpp
+++ b/fuzzing/src/targets/font-drivers/type1-render-tar.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of Type1RenderTarFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/type1-render-tar.h"
 
 
-  Type1RenderTarFuzzTarget::
-  Type1RenderTarFuzzTarget( void )
+  freetype::Type1RenderTarFuzzTarget::
+  Type1RenderTarFuzzTarget()
   {
     (void) set_data_is_tar_archive( true );
   }

--- a/fuzzing/src/targets/font-drivers/type1-render-tar.h
+++ b/fuzzing/src/targets/font-drivers/type1-render-tar.h
@@ -2,7 +2,7 @@
 //
 //   Render Type 1 faces using tar sampling data.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/type1-render.h"
 
 
+namespace freetype {
+
+
   class Type1RenderTarFuzzTarget
     : public Type1RenderFuzzTarget
   {
   public:
 
 
-    Type1RenderTarFuzzTarget( void );
+    Type1RenderTarFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TYPE_1_RENDER_TAR_H_

--- a/fuzzing/src/targets/font-drivers/type1-render.cpp
+++ b/fuzzing/src/targets/font-drivers/type1-render.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of Type1RenderFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -13,6 +13,8 @@
 
 
 #include "targets/font-drivers/type1-render.h"
+
+#include <utility> // std::move
 
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
@@ -26,59 +28,56 @@
 #include "visitors/facevisitor-subglyphs.h"
 
 
-  using namespace std;
-
-
-  Type1RenderFuzzTarget::
-  Type1RenderFuzzTarget( void )
+  freetype::Type1RenderFuzzTarget::
+  Type1RenderFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
     auto  fpi_mm =
-      fuzzing::make_unique<FacePrepIteratorMultipleMasters>();
+      freetype::make_unique<FacePrepIteratorMultipleMasters>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterators:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
 
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsOutlines>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorRenderGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorRenderGlyphs>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorSubGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorSubGlyphs>() );
 
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsOutlines>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorRenderGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorRenderGlyphs>() );
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorSubGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorSubGlyphs>() );
 
     // -----------------------------------------------------------------------
     // Face load iterators:
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::TYPE_1 );
 
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
-    (void) fli->add_iterator( move( fpi_mm       ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_mm       ) );
     
     // -----------------------------------------------------------------------
     // Fuzz target:
 
     (void) set_property( "type1", "hinting-engine", &HINTING_ADOBE );
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
 
     (void) set_data_is_tar_archive( false );
   }

--- a/fuzzing/src/targets/font-drivers/type1-render.h
+++ b/fuzzing/src/targets/font-drivers/type1-render.h
@@ -2,7 +2,7 @@
 //
 //   Render Type 1 faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class Type1RenderFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    Type1RenderFuzzTarget( void );
+    Type1RenderFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TYPE_1_RENDER_H_

--- a/fuzzing/src/targets/font-drivers/type1-tar.cpp
+++ b/fuzzing/src/targets/font-drivers/type1-tar.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of Type1TarFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/font-drivers/type1-tar.h"
 
 
-  Type1TarFuzzTarget::
-  Type1TarFuzzTarget( void )
+  freetype::Type1TarFuzzTarget::
+  Type1TarFuzzTarget()
   {
     (void) set_data_is_tar_archive( true );
   }

--- a/fuzzing/src/targets/font-drivers/type1-tar.h
+++ b/fuzzing/src/targets/font-drivers/type1-tar.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz Type 1 faces using tar sampling data.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/font-drivers/type1.h"
 
 
+namespace freetype {
+
+
   class Type1TarFuzzTarget
     : public Type1FuzzTarget
   {
   public:
 
 
-    Type1TarFuzzTarget( void );
+    Type1TarFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TYPE_1_TAR_H_

--- a/fuzzing/src/targets/font-drivers/type1.cpp
+++ b/fuzzing/src/targets/font-drivers/type1.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of Type1FuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -13,6 +13,8 @@
 
 
 #include "targets/font-drivers/type1.h"
+
+#include <utility> // std::move
 
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
@@ -27,60 +29,58 @@
 #include "visitors/facevisitor-variants.h"
 
 
-  using namespace std;
-
-
-  Type1FuzzTarget::
-  Type1FuzzTarget( void )
+  freetype::Type1FuzzTarget::
+  Type1FuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
     auto  fpi_mm =
-      fuzzing::make_unique<FacePrepIteratorMultipleMasters>();
+      freetype::make_unique<FacePrepIteratorMultipleMasters>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterators:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorKerning>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorKerning>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorKerning>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorKerning>() );
     
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorMultipleMasters>(
+      ->add_visitor( freetype::make_unique<FaceVisitorMultipleMasters>(
                        FaceLoader::FontFormat::TYPE_1) );
 
     (void) fpi_mm
-      ->add_visitor( fuzzing::make_unique<FaceVisitorType1Tables>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorType1Tables>() );
 
     // -----------------------------------------------------------------------
     // Face load iterators:
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::TYPE_1 );
 
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
-    (void) fli->add_iterator( move( fpi_mm       ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_mm       ) );
 
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorCharCodes>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorCharCodes>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorVariants>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorVariants>() );
 
     (void) fli
-      ->add_always_visitor( fuzzing::make_unique<FaceVisitorTrackKerning>() );
+      ->add_always_visitor(
+        freetype::make_unique<FaceVisitorTrackKerning>() );
     (void) fli
-      ->add_always_visitor( fuzzing::make_unique<FaceVisitorType1Tables>() );
+      ->add_always_visitor( freetype::make_unique<FaceVisitorType1Tables>() );
     
     // -----------------------------------------------------------------------
     // Fuzz target:
 
     (void) set_property( "type1", "hinting-engine", &HINTING_ADOBE );
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
 
     (void) set_data_is_tar_archive( false );
   }

--- a/fuzzing/src/targets/font-drivers/type1.h
+++ b/fuzzing/src/targets/font-drivers/type1.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz Type 1 faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class Type1FuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    Type1FuzzTarget( void );
+    Type1FuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TYPE_1_H_

--- a/fuzzing/src/targets/font-drivers/type42-render.cpp
+++ b/fuzzing/src/targets/font-drivers/type42-render.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of Type42RenderFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,6 +14,8 @@
 
 #include "targets/font-drivers/type42-render.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "iterators/faceprepiterator-outlines.h"
@@ -24,32 +26,29 @@
 #include "visitors/facevisitor-subglyphs.h"
 
 
-  using namespace std;
-
-
-  Type42RenderFuzzTarget::
-  Type42RenderFuzzTarget( void )
+  freetype::Type42RenderFuzzTarget::
+  Type42RenderFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterators:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
 
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorAutohinter>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorAutohinter>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsOutlines>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsOutlines>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorRenderGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorRenderGlyphs>() );
     (void) fpi_outlines
-      ->add_visitor( fuzzing::make_unique<FaceVisitorSubGlyphs>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorSubGlyphs>() );
 
     // -----------------------------------------------------------------------
     // Face load iterators:
@@ -57,11 +56,11 @@
     (void) fli
       ->set_supported_font_format( FaceLoader::FontFormat::TYPE_42 );
 
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/type42-render.h
+++ b/fuzzing/src/targets/font-drivers/type42-render.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for Type 42 faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class Type42RenderFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    Type42RenderFuzzTarget( void );
+    Type42RenderFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TYPE_42_RENDER_H_

--- a/fuzzing/src/targets/font-drivers/type42.cpp
+++ b/fuzzing/src/targets/font-drivers/type42.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of Type42FuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,6 +14,8 @@
 
 #include "targets/font-drivers/type42.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "iterators/faceprepiterator-outlines.h"
@@ -22,16 +24,13 @@
 #include "visitors/facevisitor-variants.h"
 
 
-  using namespace std;
-
-
-  Type42FuzzTarget::
-  Type42FuzzTarget( void )
+  freetype::Type42FuzzTarget::
+  Type42FuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
 
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
-    auto  fpi_outlines = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
+    auto  fpi_outlines = freetype::make_unique<FacePrepIteratorOutlines>();
 
 
     // -----------------------------------------------------------------------
@@ -39,19 +38,19 @@
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::TYPE_42 );
     
-    (void) fli->add_iterator( move( fpi_bitmaps  ) );
-    (void) fli->add_iterator( move( fpi_outlines ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps  ) );
+    (void) fli->add_iterator( std::move( fpi_outlines ) );
     
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorCharCodes>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorCharCodes>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorVariants>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorVariants>() );
 
     (void) fli
-      ->add_always_visitor( fuzzing::make_unique<FaceVisitorType1Tables>() );
+      ->add_always_visitor( freetype::make_unique<FaceVisitorType1Tables>() );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/type42.h
+++ b/fuzzing/src/targets/font-drivers/type42.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for Type 42 faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class Type42FuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    Type42FuzzTarget( void );
+    Type42FuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_TYPE_42_H_

--- a/fuzzing/src/targets/font-drivers/windowsfnt-render.cpp
+++ b/fuzzing/src/targets/font-drivers/windowsfnt-render.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of WindowsFntRenderFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,21 +19,18 @@
 #include "visitors/facevisitor-loadglyphs-bitmaps.h"
 
 
-  using namespace std;
-
-
-  WindowsFntRenderFuzzTarget::
-  WindowsFntRenderFuzzTarget( void )
+  freetype::WindowsFntRenderFuzzTarget::
+  WindowsFntRenderFuzzTarget()
   {
-    auto  fli          = fuzzing::make_unique<FaceLoadIterator>();
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
+    auto  fli          = freetype::make_unique<FaceLoadIterator>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
 
 
     // -----------------------------------------------------------------------
     // Face preparation iterator:
 
     (void) fpi_bitmaps
-      ->add_visitor( fuzzing::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
+      ->add_visitor( freetype::make_unique<FaceVisitorLoadGlyphsBitmaps>() );
 
     // -----------------------------------------------------------------------
     // Face load iterator:
@@ -41,10 +38,10 @@
     (void) fli
       ->set_supported_font_format( FaceLoader::FontFormat::WINDOWS_FNT );
     
-    (void) fli->add_iterator( move( fpi_bitmaps ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps ) );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/windowsfnt-render.h
+++ b/fuzzing/src/targets/font-drivers/windowsfnt-render.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for rendering Windows FNT faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class WindowsFntRenderFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    WindowsFntRenderFuzzTarget( void );
+    WindowsFntRenderFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_WINDOWS_FNT_RENDER_H_

--- a/fuzzing/src/targets/font-drivers/windowsfnt.cpp
+++ b/fuzzing/src/targets/font-drivers/windowsfnt.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of WindowsFntFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,20 +14,19 @@
 
 #include "targets/font-drivers/windowsfnt.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "visitors/facevisitor-charcodes.h"
 #include "visitors/facevisitor-windowsfnt.h"
 
 
-  using namespace std;
-
-
-  WindowsFntFuzzTarget::
-  WindowsFntFuzzTarget( void )
+  freetype::WindowsFntFuzzTarget::
+  WindowsFntFuzzTarget()
   {
-    auto  fli          = fuzzing::make_unique<FaceLoadIterator>();
-    auto  fpi_bitmaps  = fuzzing::make_unique<FacePrepIteratorBitmaps>();
+    auto  fli          = freetype::make_unique<FaceLoadIterator>();
+    auto  fpi_bitmaps  = freetype::make_unique<FacePrepIteratorBitmaps>();
 
 
     // -----------------------------------------------------------------------
@@ -36,15 +35,15 @@
     (void) fli
       ->set_supported_font_format( FaceLoader::FontFormat::WINDOWS_FNT );
     
-    (void) fli->add_iterator( move( fpi_bitmaps ) );
+    (void) fli->add_iterator( std::move( fpi_bitmaps ) );
     
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorCharCodes>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorCharCodes>() );
     (void) fli
-      ->add_once_visitor( fuzzing::make_unique<FaceVisitorWindowsFnt>() );
+      ->add_once_visitor( freetype::make_unique<FaceVisitorWindowsFnt>() );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/font-drivers/windowsfnt.h
+++ b/fuzzing/src/targets/font-drivers/windowsfnt.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for Windows FNT faces.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class WindowsFntFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    WindowsFntFuzzTarget( void );
+    WindowsFntFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_FONT_DRIVERS_WINDOWS_FNT_H_

--- a/fuzzing/src/targets/glyphs/bitmaps-pcf.cpp
+++ b/fuzzing/src/targets/glyphs/bitmaps-pcf.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphsBitmapsPcfFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,8 +15,8 @@
 #include "targets/glyphs/bitmaps-pcf.h"
 
 
-  GlyphsBitmapsPcfFuzzTarget::
-  GlyphsBitmapsPcfFuzzTarget( void )
+  freetype::GlyphsBitmapsPcfFuzzTarget::
+  GlyphsBitmapsPcfFuzzTarget()
   {
     (void) set_supported_font_format( FaceLoader::FontFormat::PCF );
   }

--- a/fuzzing/src/targets/glyphs/bitmaps-pcf.h
+++ b/fuzzing/src/targets/glyphs/bitmaps-pcf.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for PCF glyph bitmaps.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,14 +19,18 @@
 #include "targets/glyphs/bitmaps.h"
 
 
+namespace freetype {
+
+
   class GlyphsBitmapsPcfFuzzTarget
     : public GlyphsBitmapsFuzzTarget
   {
   public:
 
 
-    GlyphsBitmapsPcfFuzzTarget( void );
+    GlyphsBitmapsPcfFuzzTarget();
   };
+}
 
 
 #endif // TARGETS_GLYPHS_BITMAPS_PCF_H_

--- a/fuzzing/src/targets/glyphs/bitmaps.cpp
+++ b/fuzzing/src/targets/glyphs/bitmaps.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphsBitmapsFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,6 +14,8 @@
 
 #include "targets/glyphs/bitmaps.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-bitmaps.h"
 #include "iterators/glyphloaditerator-naive.h"
@@ -21,33 +23,35 @@
 #include "utils/logging.h"
 
 
-  const FT_Long  GlyphsBitmapsFuzzTarget::NUM_LOAD_GLYPHS = 20;
+  const FT_Long
+  freetype::GlyphsBitmapsFuzzTarget::
+  NUM_LOAD_GLYPHS = 20;
 
 
-  GlyphsBitmapsFuzzTarget::
-  GlyphsBitmapsFuzzTarget( void )
+  freetype::GlyphsBitmapsFuzzTarget::
+  GlyphsBitmapsFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
-    auto  fpi = fuzzing::make_unique<FacePrepIteratorBitmaps>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
+    auto  fpi = freetype::make_unique<FacePrepIteratorBitmaps>();
     auto  gli =
-      fuzzing::make_unique<GlyphLoadIteratorNaive>( NUM_LOAD_GLYPHS );
+      freetype::make_unique<GlyphLoadIteratorNaive>( NUM_LOAD_GLYPHS );
 
 
     // -----------------------------------------------------------------------
     // Glyph load iterators:
 
     (void) gli
-      ->add_visitor( fuzzing::make_unique<GlyphVisitorBitmapHandling>() );
+      ->add_visitor( freetype::make_unique<GlyphVisitorBitmapHandling>() );
 
     // -----------------------------------------------------------------------
     // Assemble the rest:
 
-    (void) fpi->add_iterator( move( gli ) );
+    (void) fpi->add_iterator( std::move( gli ) );
 
-    (void) fli->add_iterator( move( fpi ) );
+    (void) fli->add_iterator( std::move( fpi ) );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/glyphs/bitmaps.h
+++ b/fuzzing/src/targets/glyphs/bitmaps.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for glyph bitmaps.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,13 +19,16 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class GlyphsBitmapsFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    GlyphsBitmapsFuzzTarget( void );
+    GlyphsBitmapsFuzzTarget();
 
 
   private:
@@ -33,6 +36,7 @@
 
     static const FT_Long  NUM_LOAD_GLYPHS;
   };
+}
 
 
 #endif // TARGETS_GLYPHS_BITMAPS_H_

--- a/fuzzing/src/targets/glyphs/outlines.cpp
+++ b/fuzzing/src/targets/glyphs/outlines.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphsOutlinesFuzzTarget.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -14,6 +14,8 @@
 
 #include "targets/glyphs/outlines.h"
 
+#include <utility> // std::move
+
 #include "iterators/faceloaditerator.h"
 #include "iterators/faceprepiterator-outlines.h"
 #include "iterators/glyphloaditerator-naive.h"
@@ -24,20 +26,19 @@
 #include "utils/logging.h"
 
 
-  using namespace std;
+  const FT_Long
+  freetype::GlyphsOutlinesFuzzTarget::
+  NUM_LOAD_GLYPHS = 5;
 
 
-  const FT_Long  GlyphsOutlinesFuzzTarget::NUM_LOAD_GLYPHS = 5;
-
-
-  GlyphsOutlinesFuzzTarget::
-  GlyphsOutlinesFuzzTarget( void )
+  freetype::GlyphsOutlinesFuzzTarget::
+  GlyphsOutlinesFuzzTarget()
   {
-    auto  fli = fuzzing::make_unique<FaceLoadIterator>();
-    auto  fpi = fuzzing::make_unique<FacePrepIteratorOutlines>();
+    auto  fli = freetype::make_unique<FaceLoadIterator>();
+    auto  fpi = freetype::make_unique<FacePrepIteratorOutlines>();
     auto  gli =
-      fuzzing::make_unique<GlyphLoadIteratorNaive>( NUM_LOAD_GLYPHS );
-    auto  gri = fuzzing::make_unique<GlyphRenderIteratorAllModes>();
+      freetype::make_unique<GlyphLoadIteratorNaive>( NUM_LOAD_GLYPHS );
+    auto  gri = freetype::make_unique<GlyphRenderIteratorAllModes>();
 
 
     // -----------------------------------------------------------------------
@@ -45,22 +46,22 @@
 
     (void) gli->add_load_flags( FT_LOAD_NO_BITMAP );
 
-    (void) gli->add_iterator( move( gri ) );
+    (void) gli->add_iterator( std::move( gri ) );
 
-    (void) gli->add_visitor( fuzzing::make_unique<GlyphVisitorCBox>()      );
-    (void) gli->add_visitor( fuzzing::make_unique<GlyphVisitorOutlines>()  );
-    (void) gli->add_visitor( fuzzing::make_unique<GlyphVisitorTransform>() );
+    (void) gli->add_visitor( freetype::make_unique<GlyphVisitorCBox>()      );
+    (void) gli->add_visitor( freetype::make_unique<GlyphVisitorOutlines>()  );
+    (void) gli->add_visitor( freetype::make_unique<GlyphVisitorTransform>() );
 
     // -----------------------------------------------------------------------
     // Assemble the rest:
 
-    (void) fpi->add_iterator( move( gli ) );
+    (void) fpi->add_iterator( std::move( gli ) );
 
     (void) fli->set_supported_font_format( FaceLoader::FontFormat::TRUETYPE );
-    (void) fli->add_iterator( move( fpi ) );
+    (void) fli->add_iterator( std::move( fpi ) );
 
     // -----------------------------------------------------------------------
     // Fuzz target:
 
-    (void) set_iterator( move( fli ) );
+    (void) set_iterator( std::move( fli ) );
   }

--- a/fuzzing/src/targets/glyphs/outlines.h
+++ b/fuzzing/src/targets/glyphs/outlines.h
@@ -2,7 +2,7 @@
 //
 //   Fuzz target for glyph outlines.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,13 +19,16 @@
 #include "targets/FaceFuzzTarget.h"
 
 
+namespace freetype {
+
+
   class GlyphsOutlinesFuzzTarget
     : public FaceFuzzTarget
   {
   public:
 
 
-    GlyphsOutlinesFuzzTarget( void );
+    GlyphsOutlinesFuzzTarget();
 
 
   private:
@@ -33,6 +36,7 @@
 
     static const FT_Long  NUM_LOAD_GLYPHS;
   };
+}
 
 
 #endif // TARGETS_GLYPHS_OUTLINES_H_

--- a/fuzzing/src/targets/support/Bzip2FuzzTarget.h
+++ b/fuzzing/src/targets/support/Bzip2FuzzTarget.h
@@ -21,6 +21,7 @@
 
 namespace freetype {
 
+
   class Bzip2FuzzTarget
     : public FuzzTarget
   {

--- a/fuzzing/src/targets/support/GzipFuzzTarget.h
+++ b/fuzzing/src/targets/support/GzipFuzzTarget.h
@@ -21,6 +21,7 @@
 
 namespace freetype {
 
+
   class GzipFuzzTarget
     : public FuzzTarget
   {

--- a/fuzzing/src/targets/support/LzwFuzzTarget.h
+++ b/fuzzing/src/targets/support/LzwFuzzTarget.h
@@ -21,6 +21,7 @@
 
 namespace freetype {
 
+
   class LzwFuzzTarget
     : public FuzzTarget
   {

--- a/fuzzing/src/utils/FreeTypeStream.h
+++ b/fuzzing/src/utils/FreeTypeStream.h
@@ -18,6 +18,8 @@
 
 #include <cstdint>
 
+#include <boost/core/noncopyable.hpp>
+
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include <freetype/internal/internal.h>
@@ -26,7 +28,9 @@
 
 namespace freetype {
 
+
   class FreeTypeStream
+    : private boost::noncopyable
   {
   public:
 
@@ -39,10 +43,7 @@ namespace freetype {
                     FT_ULong        size );
 
 
-    FreeTypeStream( const FreeTypeStream& ) = delete;
-    FreeTypeStream& operator= ( const FreeTypeStream& ) = delete;
-
-
+    virtual
     ~FreeTypeStream()
     {
       (void) FT_Stream_Close( &stream );

--- a/fuzzing/src/utils/faceloader.cpp
+++ b/fuzzing/src/utils/faceloader.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceLoader.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -16,14 +16,13 @@
 
 #include <cassert>
 
-#include <ft2build.h>
 #include FT_FONT_FORMATS_H
 
 #include "utils/logging.h"
 
 
   void
-  FaceLoader::
+  freetype::FaceLoader::
   set_supported_font_format( FontFormat  format )
   {
     supported_font_format = format;
@@ -45,7 +44,7 @@
 
 
   void
-  FaceLoader::
+  freetype::FaceLoader::
   set_library( FT_Library  library )
   {
     this->library = library;
@@ -53,7 +52,7 @@
 
 
   void
-  FaceLoader::
+  freetype::FaceLoader::
   set_raw_bytes( const uint8_t*  data,
                  size_t          size )
   {
@@ -72,7 +71,7 @@
 
 
   void
-  FaceLoader::
+  freetype::FaceLoader::
   set_data_is_tar_archive( bool  is_tar_archive )
   {
     data_is_tar_archive = is_tar_archive;
@@ -80,7 +79,7 @@
 
 
   void
-  FaceLoader::
+  freetype::FaceLoader::
   set_face_index( FT_Long  index )
   {
     if ( index != face_index )
@@ -97,7 +96,7 @@
 
     
   void
-  FaceLoader::
+  freetype::FaceLoader::
   set_instance_index( FT_Long  index )
   {
     if ( index < 0 || index >= get_num_instances() )
@@ -111,8 +110,8 @@
 
 
   FT_Long
-  FaceLoader::
-  get_num_faces( void )
+  freetype::FaceLoader::
+  get_num_faces()
   {
     if ( num_faces < 0 )
     {
@@ -132,8 +131,8 @@
 
 
   FT_Long
-  FaceLoader::
-  get_num_instances( void )
+  freetype::FaceLoader::
+  get_num_instances()
   {
     if ( num_instances < 0 )
     {
@@ -152,16 +151,16 @@
   }
 
 
-  Unique_FT_Face
-  FaceLoader::
-  load( void )
+  freetype::Unique_FT_Face
+  freetype::FaceLoader::
+  load()
   {
     return load_face( face_index, instance_index );
   }
 
 
-  Unique_FT_Face
-  FaceLoader::
+  freetype::Unique_FT_Face
+  freetype::FaceLoader::
   load_face( FT_Long  face_index,
              FT_Long  instance_index )
   {
@@ -215,7 +214,7 @@
       }
     }
 
-    string  font_format( FT_Get_Font_Format( face ) );
+    std::string  font_format( FT_Get_Font_Format( face ) );
     if ( font_format != supported_font_format_string )
     {
       LOG( ERROR ) << "invalid font format: "

--- a/fuzzing/src/utils/faceloader.h
+++ b/fuzzing/src/utils/faceloader.h
@@ -2,7 +2,7 @@
 //
 //   Wrapper class to create faces from fuzzed input.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,15 +19,20 @@
 #include <string>
 #include <vector>
 
+#include <boost/core/noncopyable.hpp>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
 #include "utils/tarreader.h"
 #include "utils/utils.h"
 
 
-  using namespace fuzzing;
-  using namespace std;
+namespace freetype {
 
 
   class FaceLoader
+    : private boost::noncopyable
   {
   public:
 
@@ -48,12 +53,8 @@
     };
 
 
-    FaceLoader( void )
+    FaceLoader()
       : tarreader( files ) {}
-
-
-    FaceLoader( const FaceLoader& ) = delete;
-    FaceLoader& operator= ( const FaceLoader& ) = delete;
 
 
     // @Description:
@@ -126,11 +127,11 @@
     //   The number of faces.
 
     FT_Long
-    get_num_faces( void );
+    get_num_faces();
 
 
     FT_Long
-    get_num_instances( void );
+    get_num_instances();
       
 
     // @Description:
@@ -149,7 +150,7 @@
     //   A pointer to a face object or nullptr if any error occurred.
 
     Unique_FT_Face
-    load( void );
+    load();
 
 
   private:
@@ -159,10 +160,10 @@
     
     TarReader  tarreader;
 
-    vector<vector<FT_Byte>>  files;
+    std::vector<std::vector<FT_Byte>>  files;
 
-    FontFormat  supported_font_format        = FontFormat::NONE;
-    string      supported_font_format_string = "";
+    FontFormat   supported_font_format        = FontFormat::NONE;
+    std::string  supported_font_format_string = "";
 
     bool  data_is_tar_archive = false;
 
@@ -177,6 +178,7 @@
     load_face( FT_Long  face_index     = -1,
                FT_Long  instance_inces =  0 );
   };
+}
 
 
 #endif // UTILS_FACE_LOADER_H_

--- a/fuzzing/src/utils/logging.h
+++ b/fuzzing/src/utils/logging.h
@@ -2,7 +2,7 @@
 //
 //   Switch between different loggers and/or compile them out completely.
 //
-// Copyright 2019 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,6 +19,7 @@
 #include <iomanip>
 
 #include <ft2build.h>
+#include FT_FREETYPE_H
 #include FT_ERRORS_H
 
 #ifdef LOGGER_GLOG

--- a/fuzzing/src/utils/tarreader.cpp
+++ b/fuzzing/src/utils/tarreader.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of TarReader.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka, David Turner, Robert Wilhelm, and Werner Lemberg.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,11 +22,8 @@
 #include "utils/logging.h"
 
 
-  using namespace fuzzing;
-
-
   bool
-  TarReader::
+  freetype::TarReader::
   extract_data( const uint8_t*  data,
                 size_t          size )
   {
@@ -68,7 +65,7 @@
       size_t          buffer_size;
       off_t           offset;
 
-      vector<FT_Byte>  entry_data;
+      std::vector<FT_Byte>  entry_data;
 
 
       LOG( INFO ) << "extracting: "

--- a/fuzzing/src/utils/tarreader.h
+++ b/fuzzing/src/utils/tarreader.h
@@ -2,7 +2,7 @@
 //
 //   Used to extract files from tar archives.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -17,29 +17,30 @@
 
 #include <vector>
 
+#include <boost/core/noncopyable.hpp>
+
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
 #include "utils/utils.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class TarReader
+    : private boost::noncopyable
   {
   public:
 
 
+    typedef std::vector<std::vector<FT_Byte>>  Files;
+
     // @Input:
     //   files ::
     //     Extracted files will be added to this vector.
-    TarReader( vector<vector<FT_Byte>>&  files )
+    TarReader( Files&  files )
       : files(files) {}
-
-
-    TarReader( const TarReader& ) = delete;
-    TarReader& operator= ( const TarReader& ) = delete;
 
 
     bool
@@ -50,8 +51,9 @@
   private:
 
 
-    vector<vector<FT_Byte>>&  files;
+    Files&  files;
   };
+}
 
 
 #endif // UTILS_TAR_READER_H_

--- a/fuzzing/src/utils/utils.cpp
+++ b/fuzzing/src/utils/utils.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of utils.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -24,27 +24,24 @@
 #include "utils/logging.h"
 
 
-  using namespace fuzzing;
-
-
-  Unique_FT_Face
-  fuzzing::
+  freetype::Unique_FT_Face
+  freetype::
   make_unique_face( FT_Face  face )
   {
     return Unique_FT_Face( face, FT_Done_Face );
   }
 
 
-  Unique_FT_Glyph
-  fuzzing::
+  freetype::Unique_FT_Glyph
+  freetype::
   make_unique_glyph( FT_Glyph  glyph )
   {
     return Unique_FT_Glyph( glyph, FT_Done_Glyph );
   }
 
 
-  Unique_FT_Glyph
-  fuzzing::
+  freetype::Unique_FT_Glyph
+  freetype::
   copy_unique_glyph( const Unique_FT_Glyph&  glyph )
   {
     FT_Error  error;
@@ -58,8 +55,8 @@
   }
 
 
-  Unique_FT_Glyph
-  fuzzing::
+  freetype::Unique_FT_Glyph
+  freetype::
   get_unique_glyph_from_face( const Unique_FT_Face&  face )
   {
     FT_Error  error;
@@ -74,7 +71,7 @@
 
 
   bool
-  fuzzing::
+  freetype::
   glyph_has_reasonable_size( const Unique_FT_Glyph&  glyph,
                              FT_Pos                  reasonable_pixels )
   {
@@ -83,13 +80,13 @@
 
 
   bool
-  fuzzing::
+  freetype::
   glyph_has_reasonable_size( const Unique_FT_Glyph&  glyph,
                              FT_Pos                  reasonable_pixels,
                              FT_Pos                  reasonable_width,
                              FT_Pos                  reasonable_height )
   {
-    static const auto  POS_MAX = numeric_limits<FT_Pos>::max();
+    static const auto  POS_MAX = std::numeric_limits<FT_Pos>::max();
 
     FT_BBox  box;
     FT_Pos   pixels;
@@ -105,8 +102,8 @@
 
     (void) FT_Glyph_Get_CBox( glyph.get(), FT_GLYPH_BBOX_PIXELS, &box );
 
-    width  = abs( box.xMin - box.xMax );
-    height = abs( box.yMin - box.yMax );
+    width  = std::abs( box.xMin - box.xMax );
+    height = std::abs( box.yMin - box.yMax );
 
     LOG( INFO ) << "glyph size: " << width << " x " << height << " px\n";
 
@@ -131,7 +128,7 @@
 
 
   bool
-  fuzzing::
+  freetype::
   glyph_has_reasonable_work_size( const Unique_FT_Glyph&  glyph )
   {
     // August 2018:
@@ -144,7 +141,7 @@
 
 
   bool
-  fuzzing::
+  freetype::
   glyph_has_reasonable_render_size( const Unique_FT_Glyph&  glyph )
   {
     // August 2018:

--- a/fuzzing/src/utils/utils.h
+++ b/fuzzing/src/utils/utils.h
@@ -2,7 +2,7 @@
 //
 //   Collection of globally useful snippets.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -35,143 +35,141 @@
 #include FT_GLYPH_H
 
 
-  using namespace std;
+namespace freetype
+{
 
-  namespace fuzzing
+  typedef std::unique_ptr<struct archive,
+                          decltype( archive_read_free )*>  Unique_Archive;
+
+  typedef std::unique_ptr<FT_FaceRec,
+                          decltype( FT_Done_Face )*>  Unique_FT_Face;
+
+  typedef std::unique_ptr<FT_GlyphRec,
+                          decltype( FT_Done_Glyph )*>  Unique_FT_Glyph;
+
+
+  // @Description:
+  //   As of today (Summer 2018), `std::make_unique' is still not reliably
+  //   available.  This version of `make_unique' helps to bridge the gap
+  //   since the usefulness of `make_unique' is undisputed.
+  //   Source: https://isocpp.org/files/papers/N3656.txt
+
+  template<typename T, typename... Args>
+  std::unique_ptr<T>
+  make_unique( Args&&...  args )
   {
-
-    typedef unique_ptr<struct archive,
-      decltype( archive_read_free )*>  Unique_Archive;
-
-    typedef unique_ptr<FT_FaceRec,
-      decltype( FT_Done_Face )*>  Unique_FT_Face;
-
-    typedef unique_ptr<FT_GlyphRec,
-      decltype( FT_Done_Glyph )*>  Unique_FT_Glyph;
-
-
-    // @Description:
-    //   As of today (Summer 2018), `std::make_unique' is still not reliably
-    //   available.  This version of `make_unique' helps to bridge the gap
-    //   since the usefulness of `make_unique' is undisputed.
-    //   Source: https://isocpp.org/files/papers/N3656.txt
-
-    template<typename T, typename... Args>
-    std::unique_ptr<T>
-    make_unique( Args&&...  args )
-    {
-      return std::unique_ptr<T>( new T( std::forward<Args>( args )... ) );
-    }
-
-
-    Unique_FT_Face
-    make_unique_face( FT_Face  face=nullptr );
-
-
-    Unique_FT_Glyph
-    make_unique_glyph( FT_Glyph  glyph=nullptr );
-
-
-    // @Description:
-    //   Creates a copy of a glyph.
-    //
-    // @Input:
-    //   glyph ::
-    //     A glyph that will be copied.
-    //
-    // @Return:
-    //   A freshly created copy of the glyph.
-
-    Unique_FT_Glyph
-    copy_unique_glyph( const Unique_FT_Glyph&  glyph );
-
-
-    // @Description:
-    //   Extract a loaded glyph from the face via `FT_Get_Glyph'.  Mind: This
-    //   can only be done ONCE per loaded face as the new glyph only
-    //   references bitmaps and outlines of the face's glyph slot.  Copy the
-    //   returned glyph immediately and avoid using it directly (unless in
-    //   very special cases).
-    //
-    // @Input:
-    //   face ::
-    //     A face that has a loaded glyph in its glyph slot.
-    //
-    // @Return:
-    //   The last loaded glyph of the input face or `nullptr' if any error
-    //   occurred.
-
-    Unique_FT_Glyph
-    get_unique_glyph_from_face( const Unique_FT_Face&  face );
-
-
-    // @See: `glyph_has_reasonable_size'.
-
-    bool
-    glyph_has_reasonable_size( const Unique_FT_Glyph&  glyph,
-                               FT_Pos                  reasonable_pixels );
-
-
-    // @Description:
-    //   Check if the given glyph's bitmap exceeds certain sizes.
-    //
-    // @Input:
-    //   glyph ::
-    //     A glpyh that is to be evaluated.
-    //
-    //   reasonable_pixels ::
-    //     Amount of total pixels.  `0' means:  accept anything.
-    //
-    //   reasonable_width ::
-    //     Amount of vertical pixels.  `0' means:  accept anything.
-    //
-    //   reasonable_height ::
-    //     Amount of horizontal pixels.  `0' means:  accept anything.
-    //
-    // @Return:
-    //    `true', if the given glyph's bitmap has less than or equally many
-    //    pixels as the respective reasonabale sizes.
-
-    bool
-    glyph_has_reasonable_size( const Unique_FT_Glyph&  glyph,
-                               FT_Pos                  reasonable_pixels,
-                               FT_Pos                  reasonable_width,
-                               FT_Pos                  reasonable_height );
-
-
-    // @Description:
-    //   Check the size of the glyph and evaluate if it is worth working with
-    //   it.  This function logs all relevant details like glyph size and
-    //   success validity.
-    //
-    // @Input:
-    //   glyph ::
-    //     A glpyh that is to be evaluated.
-    //
-    // @Return:
-    //   `true', if `fuzzing::get_glyph_pixels()' is below a reasonale
-    //   threshold, `false' if it is above it.
-
-    bool
-    glyph_has_reasonable_work_size( const Unique_FT_Glyph&  glyph );
-
-
-    // @Description:
-    //   Check the size of the glyph and evaluate if it is worth rendering it
-    //   This function logs all relevant details like glyph size and success
-    //   validity.
-    //
-    // @Input:
-    //   glyph ::
-    //     A glpyh that is to be evaluated.
-    //
-    // @Return:
-    //   `true', if `fuzzing::get_glyph_pixels()' is below a reasonale
-    //   threshold, `false' if it is above it.
-
-    bool
-    glyph_has_reasonable_render_size( const Unique_FT_Glyph&  glyph );
+    return std::unique_ptr<T>( new T( std::forward<Args>( args )... ) );
   }
+
+
+  Unique_FT_Face
+  make_unique_face( FT_Face  face = nullptr );
+
+
+  Unique_FT_Glyph
+  make_unique_glyph( FT_Glyph  glyph = nullptr );
+
+
+  // @Description:
+  //   Creates a copy of a glyph.
+  //
+  // @Input:
+  //   glyph ::
+  //     A glyph that will be copied.
+  //
+  // @Return:
+  //   A freshly created copy of the glyph.
+
+  Unique_FT_Glyph
+  copy_unique_glyph( const Unique_FT_Glyph&  glyph );
+
+
+  // @Description:
+  //   Extract a loaded glyph from the face via `FT_Get_Glyph'.  Mind: This
+  //   can only be done ONCE per loaded face as the new glyph only
+  //   references bitmaps and outlines of the face's glyph slot.  Copy the
+  //   returned glyph immediately and avoid using it directly (unless in
+  //   very special cases).
+  //
+  // @Input:
+  //   face ::
+  //     A face that has a loaded glyph in its glyph slot.
+  //
+  // @Return:
+  //   The last loaded glyph of the input face or `nullptr' if any error
+  //   occurred.
+
+  Unique_FT_Glyph
+  get_unique_glyph_from_face( const Unique_FT_Face&  face );
+
+
+  // @See: `glyph_has_reasonable_size'.
+
+  bool
+  glyph_has_reasonable_size( const Unique_FT_Glyph&  glyph,
+                             FT_Pos                  reasonable_pixels );
+
+
+  // @Description:
+  //   Check if the given glyph's bitmap exceeds certain sizes.
+  //
+  // @Input:
+  //   glyph ::
+  //     A glpyh that is to be evaluated.
+  //
+  //   reasonable_pixels ::
+  //     Amount of total pixels.  `0' means:  accept anything.
+  //
+  //   reasonable_width ::
+  //     Amount of vertical pixels.  `0' means:  accept anything.
+  //
+  //   reasonable_height ::
+  //     Amount of horizontal pixels.  `0' means:  accept anything.
+  //
+  // @Return:
+  //    `true', if the given glyph's bitmap has less than or equally many
+  //    pixels as the respective reasonabale sizes.
+
+  bool
+  glyph_has_reasonable_size( const Unique_FT_Glyph&  glyph,
+                             FT_Pos                  reasonable_pixels,
+                             FT_Pos                  reasonable_width,
+                             FT_Pos                  reasonable_height );
+
+
+  // @Description:
+  //   Check the size of the glyph and evaluate if it is worth working with
+  //   it.  This function logs all relevant details like glyph size and
+  //   success validity.
+  //
+  // @Input:
+  //   glyph ::
+  //     A glpyh that is to be evaluated.
+  //
+  // @Return:
+  //   `true', if `fuzzing::get_glyph_pixels()' is below a reasonale
+  //   threshold, `false' if it is above it.
+
+  bool
+  glyph_has_reasonable_work_size( const Unique_FT_Glyph&  glyph );
+
+
+  // @Description:
+  //   Check the size of the glyph and evaluate if it is worth rendering it
+  //   This function logs all relevant details like glyph size and success
+  //   validity.
+  //
+  // @Input:
+  //   glyph ::
+  //     A glpyh that is to be evaluated.
+  //
+  // @Return:
+  //   `true', if `fuzzing::get_glyph_pixels()' is below a reasonale
+  //   threshold, `false' if it is above it.
+
+  bool
+  glyph_has_reasonable_render_size( const Unique_FT_Glyph&  glyph );
+}
 
 
 #endif // UTILS_UTILS_H_

--- a/fuzzing/src/visitors/facevisitor-autohinter.cpp
+++ b/fuzzing/src/visitors/facevisitor-autohinter.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorAutohinter.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,12 +23,9 @@
 
 
   void
-  FaceVisitorAutohinter::
+  freetype::FaceVisitorAutohinter::
   run( Unique_FT_Face  face )
   {
-    FT_Error  error;
-
-
     assert( face != nullptr );
 
     for ( auto  warping : warpings )
@@ -44,10 +41,10 @@
 
 
   void
-  FaceVisitorAutohinter::
-  set_property( Unique_FT_Face&  face,
-                const string     property_name,
-                const void*      value)
+  freetype::FaceVisitorAutohinter::
+  set_property( Unique_FT_Face&    face,
+                const std::string  property_name,
+                const void*        value)
   {
     (void) FT_Property_Set( face->glyph->library,
                             "autofitter",
@@ -57,7 +54,7 @@
 
 
   void
-  FaceVisitorAutohinter::
+  freetype::FaceVisitorAutohinter::
   load_glyphs( Unique_FT_Face&  face )
   {
     FT_Error  error;

--- a/fuzzing/src/visitors/facevisitor-autohinter.h
+++ b/fuzzing/src/visitors/facevisitor-autohinter.h
@@ -10,7 +10,7 @@
 //     - Type 1
 //     - Type 42
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -24,31 +24,20 @@
 #define VISITORS_FACE_VISITOR_AUTOHINTER_H_
 
 
+#include <string>
 #include <vector>
 
 #include "utils/utils.h"
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorAutohinter
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorAutohinter( void ) {}
-
-
-    FaceVisitorAutohinter( const FaceVisitorAutohinter& ) = delete;
-    FaceVisitorAutohinter& operator= (
-      const FaceVisitorAutohinter& ) = delete;
-
-
-    virtual
-    ~FaceVisitorAutohinter( void ) {}
 
 
     void
@@ -63,18 +52,19 @@
     static const FT_Int32  LOAD_FLAGS      = FT_LOAD_FORCE_AUTOHINT |
                                              FT_LOAD_NO_BITMAP;
 
-    FT_Bool          default_warping = 0;
-    vector<FT_Bool>  warpings{ 0, 1 };
+    FT_Bool               default_warping = 0;
+    std::vector<FT_Bool>  warpings{ 0, 1 };
 
 
     void
-    set_property( Unique_FT_Face&  face,
-                  const string     property_name,
-                  const void*      value );
+    set_property( Unique_FT_Face&    face,
+                  const std::string  property_name,
+                  const void*        value );
 
     void
     load_glyphs( Unique_FT_Face&  face );
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_AUTOHINTER_H_

--- a/fuzzing/src/visitors/facevisitor-bdf.cpp
+++ b/fuzzing/src/visitors/facevisitor-bdf.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorBdf.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,7 +22,7 @@
 #include "utils/logging.h"
 
 
-  FaceVisitorBdf::
+  freetype::FaceVisitorBdf::
   FaceVisitorBdf( FaceLoader::FontFormat  format )
   {
     font_format = format;
@@ -30,7 +30,7 @@
 
 
   void
-  FaceVisitorBdf::
+  freetype::FaceVisitorBdf::
   run( Unique_FT_Face  face )
   {
     FT_Error     error;
@@ -49,8 +49,10 @@
 
       if ( error == 0 )
       {
-        LOG( INFO ) << "BDF charset encoding: " << string( charset_encoding );
-        LOG( INFO ) << "BDF charset registry: " << string( charset_registry );
+        LOG( INFO ) << "BDF charset encoding: "
+                    << std::string( charset_encoding );
+        LOG( INFO ) << "BDF charset registry: "
+                    << std::string( charset_registry );
       }
     }
   }

--- a/fuzzing/src/visitors/facevisitor-bdf.h
+++ b/fuzzing/src/visitors/facevisitor-bdf.h
@@ -6,7 +6,7 @@
 //     - BDF
 //     - PCF
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -25,24 +25,16 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorBdf
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
 
 
     FaceVisitorBdf( FaceLoader::FontFormat  format );
-
-
-    FaceVisitorBdf( const FaceVisitorBdf& ) = delete;
-    FaceVisitorBdf& operator= ( const FaceVisitorBdf& ) = delete;
-
-    
-    virtual
-    ~FaceVisitorBdf( void ) {}
 
 
     void
@@ -55,6 +47,7 @@
 
     FaceLoader::FontFormat  font_format;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_BDF_H_

--- a/fuzzing/src/visitors/facevisitor-charcodes.cpp
+++ b/fuzzing/src/visitors/facevisitor-charcodes.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorCharCodes.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,30 +19,30 @@
 #include "utils/logging.h"
 
 
-  FaceVisitorCharCodes::
-  FaceVisitorCharCodes( void )
+  freetype::FaceVisitorCharCodes::
+  FaceVisitorCharCodes()
   {
     encodings = {
-      make_pair( FT_ENCODING_NONE,           "none"           ),
-      make_pair( FT_ENCODING_MS_SYMBOL,      "ms symbol"      ),
-      make_pair( FT_ENCODING_UNICODE,        "unicode"        ),
-      make_pair( FT_ENCODING_SJIS,           "sjis"           ),
-      make_pair( FT_ENCODING_PRC,            "prc"            ),
-      make_pair( FT_ENCODING_BIG5,           "big5"           ),
-      make_pair( FT_ENCODING_WANSUNG,        "wansung"        ),
-      make_pair( FT_ENCODING_JOHAB,          "johab"          ),
-      make_pair( FT_ENCODING_ADOBE_STANDARD, "adobe standard" ),
-      make_pair( FT_ENCODING_ADOBE_EXPERT,   "adobe expert"   ),
-      make_pair( FT_ENCODING_ADOBE_CUSTOM,   "adobe custom"   ),
-      make_pair( FT_ENCODING_ADOBE_LATIN_1,  "adobe latin 1"  ),
-      make_pair( FT_ENCODING_OLD_LATIN_2,    "old latin 2"    ),
-      make_pair( FT_ENCODING_APPLE_ROMAN,    "apple roman"    )
+      std::make_pair( FT_ENCODING_NONE,           "none"           ),
+      std::make_pair( FT_ENCODING_MS_SYMBOL,      "ms symbol"      ),
+      std::make_pair( FT_ENCODING_UNICODE,        "unicode"        ),
+      std::make_pair( FT_ENCODING_SJIS,           "sjis"           ),
+      std::make_pair( FT_ENCODING_PRC,            "prc"            ),
+      std::make_pair( FT_ENCODING_BIG5,           "big5"           ),
+      std::make_pair( FT_ENCODING_WANSUNG,        "wansung"        ),
+      std::make_pair( FT_ENCODING_JOHAB,          "johab"          ),
+      std::make_pair( FT_ENCODING_ADOBE_STANDARD, "adobe standard" ),
+      std::make_pair( FT_ENCODING_ADOBE_EXPERT,   "adobe expert"   ),
+      std::make_pair( FT_ENCODING_ADOBE_CUSTOM,   "adobe custom"   ),
+      std::make_pair( FT_ENCODING_ADOBE_LATIN_1,  "adobe latin 1"  ),
+      std::make_pair( FT_ENCODING_OLD_LATIN_2,    "old latin 2"    ),
+      std::make_pair( FT_ENCODING_APPLE_ROMAN,    "apple roman"    )
     };
   }
   
 
   void
-  FaceVisitorCharCodes::
+  freetype::FaceVisitorCharCodes::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
@@ -99,7 +99,7 @@
 
 
   void
-  FaceVisitorCharCodes::
+  freetype::FaceVisitorCharCodes::
   slide_along( const Unique_FT_Face&  face )
   {
     FT_Error  error;

--- a/fuzzing/src/visitors/facevisitor-charcodes.h
+++ b/fuzzing/src/visitors/facevisitor-charcodes.h
@@ -4,7 +4,7 @@
 //
 //   Drivers: all
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -17,32 +17,24 @@
 #ifndef VISITORS_FACE_VISITOR_CHARCODES_H_
 #define VISITORS_FACE_VISITOR_CHARCODES_H_
 
+
+#include <utility> // std::pair
 #include <vector>
 
 #include "utils/utils.h"
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorCharCodes
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
 
 
-    FaceVisitorCharCodes( void );
-
-
-    FaceVisitorCharCodes(
-      const FaceVisitorCharCodes& ) = delete;
-    FaceVisitorCharCodes& operator= (
-      const FaceVisitorCharCodes& ) = delete;
-
-
-    virtual
-    ~FaceVisitorCharCodes( void ) {}
+    FaceVisitorCharCodes();
 
 
     void
@@ -52,12 +44,15 @@
 
   private:
 
-    
+
+    typedef std::vector<std::pair<FT_Encoding, std::string>>  Encodings;
+
+
     // These operations are cheap but no need to exaggerate:
     static const FT_UInt  SLIDE_ALONG_MAX   = 50;
     static const FT_Int   CHARMAP_INDEX_MAX = 10;
 
-    vector<pair<FT_Encoding, string>>  encodings;
+    Encodings  encodings;
 
 
     // @Description:
@@ -71,6 +66,7 @@
     void
     slide_along( const Unique_FT_Face&  face );
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_CHARCODES_H_

--- a/fuzzing/src/visitors/facevisitor-cid.cpp
+++ b/fuzzing/src/visitors/facevisitor-cid.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorCid.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,7 +23,7 @@
 
 
   void
-  FaceVisitorCid::
+  freetype::FaceVisitorCid::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;

--- a/fuzzing/src/visitors/facevisitor-cid.h
+++ b/fuzzing/src/visitors/facevisitor-cid.h
@@ -6,7 +6,7 @@
 //     - CID Type 1
 //     - CFF
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -24,24 +24,13 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorCid
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorCid( void ) {}
-
-
-    FaceVisitorCid( const FaceVisitorCid& ) = delete;
-    FaceVisitorCid& operator= ( const FaceVisitorCid& ) = delete;
-
-
-    virtual
-    ~FaceVisitorCid( void ) {}
 
 
     void
@@ -54,6 +43,7 @@
 
     static const FT_Long  GLYPH_INDEX_MAX = 50;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_CID_H_

--- a/fuzzing/src/visitors/facevisitor-gasp.cpp
+++ b/fuzzing/src/visitors/facevisitor-gasp.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorGasp.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,11 +23,10 @@
 
 
   void
-  FaceVisitorGasp::
+  freetype::FaceVisitorGasp::
   run( Unique_FT_Face  face )
   {
-    FT_Error  error;
-    FT_Int    flags;
+    FT_Int  flags;
 
 
     assert( face != nullptr );
@@ -35,6 +34,6 @@
     for ( auto  ppem : ppems )
     {
       flags = FT_Get_Gasp( face.get(), ppem );
-      LOG( INFO ) << "gasp: " << hex << "0x" << flags;
+      LOG( INFO ) << "gasp: " << std::hex << "0x" << flags;
     }
   }

--- a/fuzzing/src/visitors/facevisitor-gasp.h
+++ b/fuzzing/src/visitors/facevisitor-gasp.h
@@ -6,7 +6,7 @@
 //     - CFF
 //     - TrueType
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -26,24 +26,13 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorGasp
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorGasp( void ) {}
-
-
-    FaceVisitorGasp( const FaceVisitorGasp& ) = delete;
-    FaceVisitorGasp& operator= ( const FaceVisitorGasp& ) = delete;
-
-    
-    virtual
-    ~FaceVisitorGasp( void ) {}
 
 
     void
@@ -55,8 +44,9 @@
 
 
     // some arbitrary seeds:
-    vector<FT_UInt>  ppems{ 8, 16, 32, 64 };
+    std::vector<FT_UInt>  ppems{ 8, 16, 32, 64 };
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_GASP_H_

--- a/fuzzing/src/visitors/facevisitor-kerning.cpp
+++ b/fuzzing/src/visitors/facevisitor-kerning.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorKerning.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -20,7 +20,7 @@
 
 
   void
-  FaceVisitorKerning::
+  freetype::FaceVisitorKerning::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;

--- a/fuzzing/src/visitors/facevisitor-kerning.h
+++ b/fuzzing/src/visitors/facevisitor-kerning.h
@@ -8,7 +8,7 @@
 //     - TrueType
 //     - Type 1
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -26,24 +26,13 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorKerning
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorKerning( void ) {}
-
-
-    FaceVisitorKerning( const FaceVisitorKerning& ) = delete;
-    FaceVisitorKerning& operator= ( const FaceVisitorKerning& ) = delete;
-
-    
-    virtual
-    ~FaceVisitorKerning( void ) {}
 
 
     void
@@ -60,6 +49,7 @@
     //   - 3 kerning modes
     static const FT_Long  MAX_GLYPH_INDEX = 20;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_KERNING_H_

--- a/fuzzing/src/visitors/facevisitor-loadglyphs-bitmaps.cpp
+++ b/fuzzing/src/visitors/facevisitor-loadglyphs-bitmaps.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorLoadGlyphsBitmaps.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,11 +15,13 @@
 #include "visitors/facevisitor-loadglyphs-bitmaps.h"
 
 
-  const FT_Long  FaceVisitorLoadGlyphsBitmaps::NUM_USED_GLYPHS = 30;
+  const FT_Long
+  freetype::FaceVisitorLoadGlyphsBitmaps::
+  NUM_USED_GLYPHS = 30;
 
 
-  FaceVisitorLoadGlyphsBitmaps::
-  FaceVisitorLoadGlyphsBitmaps( void )
+  freetype::FaceVisitorLoadGlyphsBitmaps::
+  FaceVisitorLoadGlyphsBitmaps()
     : FaceVisitorLoadGlyphs( NUM_USED_GLYPHS )
   {
     (void) add_load_flags( FT_LOAD_DEFAULT             );

--- a/fuzzing/src/visitors/facevisitor-loadglyphs-bitmaps.h
+++ b/fuzzing/src/visitors/facevisitor-loadglyphs-bitmaps.h
@@ -4,7 +4,7 @@
 //
 //   Drivers: all
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -21,23 +21,16 @@
 #include "visitors/facevisitor-loadglyphs.h"
 
 
+namespace freetype {
+
+
   class FaceVisitorLoadGlyphsBitmaps
-  : public FaceVisitorLoadGlyphs
+    : public FaceVisitorLoadGlyphs
   {
   public:
 
 
-    FaceVisitorLoadGlyphsBitmaps( void );
-
-
-    FaceVisitorLoadGlyphsBitmaps(
-      const FaceVisitorLoadGlyphsBitmaps& ) = delete;
-    FaceVisitorLoadGlyphsBitmaps& operator= (
-      const FaceVisitorLoadGlyphsBitmaps& ) = delete;
-
-
-    virtual
-    ~FaceVisitorLoadGlyphsBitmaps( void ) {}
+    FaceVisitorLoadGlyphsBitmaps();
 
 
   private:
@@ -45,6 +38,7 @@
 
     static const FT_Long  NUM_USED_GLYPHS;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_LOAD_GLYPHS_BITMAPS_H_

--- a/fuzzing/src/visitors/facevisitor-loadglyphs-outlines.cpp
+++ b/fuzzing/src/visitors/facevisitor-loadglyphs-outlines.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorLoadGlyphsOutlines.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,11 +15,13 @@
 #include "visitors/facevisitor-loadglyphs-outlines.h"
 
 
-  const FT_Long  FaceVisitorLoadGlyphsOutlines::NUM_USED_GLYPHS = 5;
+  const FT_Long
+  freetype::FaceVisitorLoadGlyphsOutlines::
+  NUM_USED_GLYPHS = 5;
 
 
-  FaceVisitorLoadGlyphsOutlines::
-  FaceVisitorLoadGlyphsOutlines( void )
+  freetype::FaceVisitorLoadGlyphsOutlines::
+  FaceVisitorLoadGlyphsOutlines()
     : FaceVisitorLoadGlyphs( NUM_USED_GLYPHS )
   {
     // Notes:

--- a/fuzzing/src/visitors/facevisitor-loadglyphs-outlines.h
+++ b/fuzzing/src/visitors/facevisitor-loadglyphs-outlines.h
@@ -10,7 +10,7 @@
 //     - Type 1
 //     - Type 42
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -27,23 +27,16 @@
 #include "visitors/facevisitor-loadglyphs.h"
 
 
+namespace freetype {
+
+
   class FaceVisitorLoadGlyphsOutlines
-  : public FaceVisitorLoadGlyphs
+    : public FaceVisitorLoadGlyphs
   {
   public:
 
 
-    FaceVisitorLoadGlyphsOutlines( void );
-
-
-    FaceVisitorLoadGlyphsOutlines(
-      const FaceVisitorLoadGlyphsOutlines& ) = delete;
-    FaceVisitorLoadGlyphsOutlines& operator= (
-      const FaceVisitorLoadGlyphsOutlines& ) = delete;
-
-
-    virtual
-    ~FaceVisitorLoadGlyphsOutlines( void ) {}
+    FaceVisitorLoadGlyphsOutlines();
 
 
   private:
@@ -54,6 +47,7 @@
     FT_Matrix  matrix;
     FT_Vector  delta;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_LOAD_GLYPHS_OUTLINES_H_

--- a/fuzzing/src/visitors/facevisitor-loadglyphs.cpp
+++ b/fuzzing/src/visitors/facevisitor-loadglyphs.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorLoadGlyphs.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,12 +15,11 @@
 #include "visitors/facevisitor-loadglyphs.h"
 
 #include <cassert>
-#include <set>
 
 #include "utils/logging.h"
 
 
-  FaceVisitorLoadGlyphs::
+  freetype::FaceVisitorLoadGlyphs::
   FaceVisitorLoadGlyphs( FT_Long  num_used_glyphs )
   {
     (void) set_num_used_glyphs( num_used_glyphs );
@@ -29,7 +28,7 @@
 
 
   void
-  FaceVisitorLoadGlyphs::
+  freetype::FaceVisitorLoadGlyphs::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
@@ -70,7 +69,7 @@
 
         for ( auto  flags : load_flags )
         {
-          LOG( INFO ) << "load flags: 0x" << hex << flags;
+          LOG( INFO ) << "load flags: 0x" << std::hex << flags;
 
           error = FT_Load_Glyph( face.get(), index, flags );
           LOG_FT_ERROR( "FT_Load_Glyph", error );
@@ -83,7 +82,7 @@
 
 
   void
-  FaceVisitorLoadGlyphs::
+  freetype::FaceVisitorLoadGlyphs::
   set_num_used_glyphs( FT_Long  glyphs )
   {
     assert( glyphs > 0 );
@@ -92,7 +91,7 @@
 
 
   void
-  FaceVisitorLoadGlyphs::
+  freetype::FaceVisitorLoadGlyphs::
   add_transformation( FT_Matrix*  matrix,
                       FT_Vector*  delta )
   {
@@ -101,7 +100,7 @@
 
 
   void
-  FaceVisitorLoadGlyphs::
+  freetype::FaceVisitorLoadGlyphs::
   add_load_flags( FT_Int32  load_flags )
   {
     (void) this->load_flags.push_back( load_flags );

--- a/fuzzing/src/visitors/facevisitor-loadglyphs.h
+++ b/fuzzing/src/visitors/facevisitor-loadglyphs.h
@@ -4,7 +4,7 @@
 //
 //   Drivers: all
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -18,17 +18,18 @@
 #define VISITORS_FACE_VISITOR_LOAD_GLYPHS_H_
 
 
+#include <utility> // std::pair
 #include <vector>
 
 #include "utils/utils.h"
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorLoadGlyphs
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
 
@@ -36,15 +37,6 @@
     // @See: `FaceVisitorLoadGlyphs::set_num_used_glyphs()'.
 
     FaceVisitorLoadGlyphs( FT_Long  num_used_glyphs );
-
-
-    FaceVisitorLoadGlyphs( const FaceVisitorLoadGlyphs& ) = delete;
-    FaceVisitorLoadGlyphs& operator= (
-      const FaceVisitorLoadGlyphs& ) = delete;
-
-
-    virtual
-    ~FaceVisitorLoadGlyphs( void ) {}
 
 
     void
@@ -100,11 +92,15 @@
   private:
 
 
+    typedef std::vector<std::pair<FT_Matrix*, FT_Vector*>>  Transformations;
+
+
     FT_Long  num_used_glyphs = -1;
 
-    vector<pair<FT_Matrix*, FT_Vector*>>  transformations;
-    vector<FT_Int32>                      load_flags;
+    Transformations        transformations;
+    std::vector<FT_Int32>  load_flags;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_LOAD_GLYPHS_H_

--- a/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
+++ b/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorMultipleMasters.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -18,7 +18,7 @@
 #include "utils/logging.h"
 
 
-  FaceVisitorMultipleMasters::
+  freetype::FaceVisitorMultipleMasters::
   FaceVisitorMultipleMasters( FaceLoader::FontFormat  format )
   {
     has_adobe_mm = format == FaceLoader::FontFormat::TYPE_1 ? true : false;
@@ -26,7 +26,7 @@
 
 
   void
-  FaceVisitorMultipleMasters::
+  freetype::FaceVisitorMultipleMasters::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
@@ -35,10 +35,10 @@
     FT_Multi_Master  master;
     FT_MM_Var*       var;
 
-    vector<FT_Long>   coords_mm_design;
-    vector<FT_Fixed>  coords_var_design;
-    vector<FT_Fixed>  coords_mm_blend;
-    vector<FT_Fixed>  coords_var_blend;
+    std::vector<FT_Long>   coords_mm_design;
+    std::vector<FT_Fixed>  coords_var_design;
+    std::vector<FT_Fixed>  coords_mm_blend;
+    std::vector<FT_Fixed>  coords_var_blend;
 
 
     if ( face == nullptr )
@@ -134,7 +134,7 @@
       LOG_FT_ERROR( "FT_Get_Var_Axis_Flags", error );
 
       LOG_IF( INFO, error == 0 )
-        << "flags of axis " << ( i + 1 ) << ": " << hex << "0x" << flags;
+        << "flags of axis " << ( i + 1 ) << ": " << std::hex << "0x" << flags;
     }
 
     for ( auto  i = 0; i < var->num_namedstyles; i++ )
@@ -151,10 +151,10 @@
 
 
   void
-  FaceVisitorMultipleMasters::
+  freetype::FaceVisitorMultipleMasters::
   test_coords( Unique_FT_Face&                             face,
-               vector<FT_Fixed>&                           coords,
-               const string&                               fn_name,
+               std::vector<FT_Fixed>&                      coords,
+               const std::string&                          fn_name,
                decltype( FT_Set_Var_Design_Coordinates )*  fn )
   {
     FT_Error  error;

--- a/fuzzing/src/visitors/facevisitor-multiplemasters.h
+++ b/fuzzing/src/visitors/facevisitor-multiplemasters.h
@@ -8,7 +8,7 @@
 //     - TrueType
 //     - Type 1
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,6 +22,7 @@
 #define VISITORS_FACE_VISITOR_MULTIPLE_MASTERS_H_
 
 
+#include <string>
 #include <vector>
 
 #include <ft2build.h>
@@ -32,11 +33,11 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorMultipleMasters
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
 
@@ -51,16 +52,6 @@
     //     Set the format.
 
     FaceVisitorMultipleMasters( FaceLoader::FontFormat  format );
-
-
-    FaceVisitorMultipleMasters(
-      const FaceVisitorMultipleMasters& ) = delete;
-    FaceVisitorMultipleMasters& operator= (
-      const FaceVisitorMultipleMasters& ) = delete;
-
-
-    virtual
-    ~FaceVisitorMultipleMasters( void ) {}
 
 
     void
@@ -91,10 +82,11 @@
 
     void
     test_coords( Unique_FT_Face&                             face,
-                 vector<FT_Fixed>&                           coords,
-                 const string&                               fn_name,
+                 std::vector<FT_Fixed>&                      coords,
+                 const std::string&                          fn_name,
                  decltype( FT_Set_Var_Design_Coordinates )*  fn );
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_MULTIPLE_MASTERS_H_

--- a/fuzzing/src/visitors/facevisitor-renderglyphs.cpp
+++ b/fuzzing/src/visitors/facevisitor-renderglyphs.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorRenderGlyphs.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,13 +15,13 @@
 #include "visitors/facevisitor-renderglyphs.h"
 
 #include <cassert>
-#include <set>
 
 #include "utils/logging.h"
 
 
-  const vector<pair<FT_Int32, FT_Render_Mode>>
-  FaceVisitorRenderGlyphs::RENDER_MODES =
+  const freetype::FaceVisitorRenderGlyphs::RenderModes
+  freetype::FaceVisitorRenderGlyphs::
+  RENDER_MODES =
   {
     { FT_LOAD_NO_BITMAP | FT_LOAD_TARGET_NORMAL, FT_RENDER_MODE_NORMAL },
     { FT_LOAD_NO_BITMAP | FT_LOAD_TARGET_LIGHT,  FT_RENDER_MODE_LIGHT  },
@@ -32,7 +32,7 @@
 
 
   void
-  FaceVisitorRenderGlyphs::
+  freetype::FaceVisitorRenderGlyphs::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
@@ -52,7 +52,7 @@
 
       for ( auto  mode : RENDER_MODES )
       {
-        LOG( INFO ) << "load flags: 0x" << hex << mode.first;
+        LOG( INFO ) << "load flags: 0x" << std::hex << mode.first;
 
         error = FT_Load_Glyph( face.get(), index, mode.first );
         LOG_FT_ERROR( "FT_Load_Glyph", error );

--- a/fuzzing/src/visitors/facevisitor-renderglyphs.h
+++ b/fuzzing/src/visitors/facevisitor-renderglyphs.h
@@ -10,7 +10,7 @@
 //     - Type 1
 //     - Type 42
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -25,30 +25,19 @@
 
 
 #include <vector>
+#include <utility> // std::pair
 
 #include "utils/utils.h"
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorRenderGlyphs
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorRenderGlyphs( void ) {}
-
-
-    FaceVisitorRenderGlyphs( const FaceVisitorRenderGlyphs& ) = delete;
-    FaceVisitorRenderGlyphs& operator= (
-      const FaceVisitorRenderGlyphs& ) = delete;
-
-
-    virtual
-    ~FaceVisitorRenderGlyphs( void ) {}
 
 
     void
@@ -59,10 +48,12 @@
   private:
 
 
-    static const FT_Long  GLYPH_INDEX_MAX = 5;
+    typedef std::vector<std::pair<FT_Int32, FT_Render_Mode>>  RenderModes;
 
-    static const vector<pair<FT_Int32, FT_Render_Mode>>  RENDER_MODES;
+    static const FT_Long      GLYPH_INDEX_MAX = 5;
+    static const RenderModes  RENDER_MODES;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_RENDER_GLYPHS_H_

--- a/fuzzing/src/visitors/facevisitor-sfntnames.cpp
+++ b/fuzzing/src/visitors/facevisitor-sfntnames.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of SfntNames.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,7 +23,7 @@
 
 
   void
-  FaceVisitorSfntNames::
+  freetype::FaceVisitorSfntNames::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
@@ -57,8 +57,8 @@
         << sfnt_name.encoding_id << "/"
         << sfnt_name.language_id << "/"
         << sfnt_name.name_id << ": "
-        << "'" << string( reinterpret_cast<char*>( sfnt_name.string ),
-                          sfnt_name.string_len ) << "'";
+        << "'" << std::string( reinterpret_cast<char*>( sfnt_name.string ),
+                               sfnt_name.string_len ) << "'";
 
       // [...] values equal or larger than 0x8000 [...] indicate a language
       // tag string [...]. Use [...] `FT_Get_Sfnt_LangTag' [...] to retrieve
@@ -75,8 +75,8 @@
       LOG_IF( INFO, error == 0 )
         << "sfnt lang tag "
         << ( index + 1 ) << "/" << num_sfnt_names << ": "
-        << "'" << string( reinterpret_cast<char*>( sfnt_lang.string ),
-                          sfnt_lang.string_len ) << "'";
+        << "'" << std::string( reinterpret_cast<char*>( sfnt_lang.string ),
+                               sfnt_lang.string_len ) << "'";
     }
 
     WARN_ABOUT_IGNORED_VALUES( num_sfnt_names, SFNT_NAME_MAX, "names" );

--- a/fuzzing/src/visitors/facevisitor-sfntnames.h
+++ b/fuzzing/src/visitors/facevisitor-sfntnames.h
@@ -6,7 +6,7 @@
 //     - CFF
 //     - TrueType
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -24,24 +24,13 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorSfntNames
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorSfntNames( void ) {}
-
-
-    FaceVisitorSfntNames( const FaceVisitorSfntNames& ) = delete;
-    FaceVisitorSfntNames& operator= ( const FaceVisitorSfntNames& ) = delete;
-
-
-    virtual
-    ~FaceVisitorSfntNames( void ) {}
 
 
     void
@@ -54,6 +43,7 @@
 
     static const FT_UInt  SFNT_NAME_MAX = 20;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_SFNT_NAMES_H_

--- a/fuzzing/src/visitors/facevisitor-subglyphs.cpp
+++ b/fuzzing/src/visitors/facevisitor-subglyphs.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorSubGlyphs.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -20,7 +20,7 @@
 
 
   void
-  FaceVisitorSubGlyphs::
+  freetype::FaceVisitorSubGlyphs::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
@@ -77,7 +77,7 @@
         LOG_IF( INFO, error == 0 )
           << "subglyph " << ( sub_index + 1 ) << "/" << num_subglyphs << ": "
           << "glyph #" << sg_index << ", "
-          << "flags 0x" << hex << sg_flags;
+          << "flags 0x" << std::hex << sg_flags;
       }
 
       WARN_ABOUT_IGNORED_VALUES( num_subglyphs,

--- a/fuzzing/src/visitors/facevisitor-subglyphs.h
+++ b/fuzzing/src/visitors/facevisitor-subglyphs.h
@@ -10,7 +10,7 @@
 //     - Type 1
 //     - Type 42
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -28,24 +28,13 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorSubGlyphs
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorSubGlyphs( void ) {}
-
-
-    FaceVisitorSubGlyphs( const FaceVisitorSubGlyphs& ) = delete;
-    FaceVisitorSubGlyphs& operator= ( const FaceVisitorSubGlyphs& ) = delete;
-
-
-    virtual
-    ~FaceVisitorSubGlyphs( void ) {}
 
 
     void
@@ -61,6 +50,7 @@
     static const FT_Int32  LOAD_FLAGS         = FT_LOAD_NO_BITMAP |
                                                 FT_LOAD_NO_RECURSE;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_SUBGLYPHS_H_

--- a/fuzzing/src/visitors/facevisitor-trackkerning.cpp
+++ b/fuzzing/src/visitors/facevisitor-trackkerning.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorTrackKerning.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,8 +19,8 @@
 #include "utils/logging.h"
 
 
-  FaceVisitorTrackKerning::
-  FaceVisitorTrackKerning( void )
+  freetype::FaceVisitorTrackKerning::
+  FaceVisitorTrackKerning()
   {
     // some arbitrary seeds:
 
@@ -40,7 +40,7 @@
   
 
   void
-  FaceVisitorTrackKerning::
+  freetype::FaceVisitorTrackKerning::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;

--- a/fuzzing/src/visitors/facevisitor-trackkerning.h
+++ b/fuzzing/src/visitors/facevisitor-trackkerning.h
@@ -5,7 +5,7 @@
 //   Drivers:
 //     - Type 1
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -25,25 +25,16 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorTrackKerning
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
 
 
-    FaceVisitorTrackKerning( void );
-
-
-    FaceVisitorTrackKerning( const FaceVisitorTrackKerning& ) = delete;
-    FaceVisitorTrackKerning& operator= (
-      const FaceVisitorTrackKerning& ) = delete;
-
-    
-    virtual
-    ~FaceVisitorTrackKerning( void ) {}
+    FaceVisitorTrackKerning();
 
 
     void
@@ -54,9 +45,10 @@
   private:
 
 
-    vector<FT_Fixed>  point_sizes;
-    vector<FT_Int>    degrees;
+    std::vector<FT_Fixed>  point_sizes;
+    std::vector<FT_Int>    degrees;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_TRACK_KERNING_H_

--- a/fuzzing/src/visitors/facevisitor-truetypepatents.cpp
+++ b/fuzzing/src/visitors/facevisitor-truetypepatents.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorTrueTypePatents.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -20,7 +20,7 @@
 
 
   void
-  FaceVisitorTrueTypePatents::
+  freetype::FaceVisitorTrueTypePatents::
   run( Unique_FT_Face  face )
   {
     FT_Bool  ret;

--- a/fuzzing/src/visitors/facevisitor-truetypepatents.h
+++ b/fuzzing/src/visitors/facevisitor-truetypepatents.h
@@ -6,7 +6,7 @@
 //   Drivers:
 //     - TrueType
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -24,32 +24,20 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorTrueTypePatents
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorTrueTypePatents( void ) {}
-
-
-    FaceVisitorTrueTypePatents(
-      const FaceVisitorTrueTypePatents& ) = delete;
-    FaceVisitorTrueTypePatents& operator= (
-      const FaceVisitorTrueTypePatents& ) = delete;
-
-
-    virtual
-    ~FaceVisitorTrueTypePatents( void ) {}
 
 
     void
     run( Unique_FT_Face  face )
     override;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_TRUETYPE_PATENTS_H_

--- a/fuzzing/src/visitors/facevisitor-truetypetables.cpp
+++ b/fuzzing/src/visitors/facevisitor-truetypetables.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorTrueTypeTables.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,7 +23,7 @@
 
 
   void
-  FaceVisitorTrueTypeTables::
+  freetype::FaceVisitorTrueTypeTables::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;

--- a/fuzzing/src/visitors/facevisitor-truetypetables.h
+++ b/fuzzing/src/visitors/facevisitor-truetypetables.h
@@ -6,7 +6,7 @@
 //     - CFF
 //     - TrueType
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -24,26 +24,13 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorTrueTypeTables
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorTrueTypeTables( void ) {}
-
-
-    FaceVisitorTrueTypeTables(
-      const FaceVisitorTrueTypeTables& ) = delete;
-    FaceVisitorTrueTypeTables& operator= (
-      const FaceVisitorTrueTypeTables& ) = delete;
-
-
-    virtual
-    ~FaceVisitorTrueTypeTables( void ) {}
 
 
     void
@@ -56,6 +43,7 @@
 
     static const FT_ULong  TABLE_INDEX_MAX = 20;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_TRUETYPE_TABLES_H_

--- a/fuzzing/src/visitors/facevisitor-type1tables.cpp
+++ b/fuzzing/src/visitors/facevisitor-type1tables.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorType1Tables.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,10 +15,11 @@
 #include "visitors/facevisitor-type1tables.h"
 
 #include <cassert>
+#include <vector>
 
 
   void
-  FaceVisitorType1Tables::
+  freetype::FaceVisitorType1Tables::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
@@ -37,7 +38,7 @@
     FT_Short         short_buffer;
     FT_UShort        ushort_buffer;
 
-    vector<FT_String>  string_buffer;
+    std::vector<FT_String>  string_buffer;
 
     FT_Int   num_char_strings;
     FT_Int   num_subrs;
@@ -203,21 +204,21 @@
 
 
   void
-  FaceVisitorType1Tables::
-  get_string( Unique_FT_Face&     face,
-              PS_Dict_Keys        key,
-              vector<FT_String>&  str )
+  freetype::FaceVisitorType1Tables::
+  get_string( Unique_FT_Face&          face,
+              PS_Dict_Keys             key,
+              std::vector<FT_String>&  str )
   {
     (void) get_string( face, key, 0, str );
   }
 
 
   void
-  FaceVisitorType1Tables::
-  get_string( Unique_FT_Face&     face,
-              PS_Dict_Keys        key,
-              FT_UInt             index,
-              vector<FT_String>&  str )
+  freetype::FaceVisitorType1Tables::
+  get_string( Unique_FT_Face&          face,
+              PS_Dict_Keys             key,
+              FT_UInt                  index,
+              std::vector<FT_String>&  str )
   {
     FT_Long  size;
 
@@ -244,18 +245,18 @@
                                  size );
 
     LOG( INFO ) << key << "[" << index << "]: '"
-                << string( str.begin(), str.end() ) << "'";
+                << std::string( str.begin(), str.end() ) << "'";
   }
 
 
   void
-  FaceVisitorType1Tables::
-  loop_string( Unique_FT_Face&     face,
-               size_t              max_value_computed,
-               size_t              max_value_static,
-               string              values_name,
-               PS_Dict_Keys        key,
-               vector<FT_String>&  value )
+  freetype::FaceVisitorType1Tables::
+  loop_string( Unique_FT_Face&          face,
+               size_t                   max_value_computed,
+               size_t                   max_value_static,
+               std::string              values_name,
+               PS_Dict_Keys             key,
+               std::vector<FT_String>&  value )
   {
     for ( auto  index = 0;
           index < max_value_computed &&

--- a/fuzzing/src/visitors/facevisitor-type1tables.h
+++ b/fuzzing/src/visitors/facevisitor-type1tables.h
@@ -9,7 +9,7 @@
 //     - Type 1
 //     - Type 42
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,6 +23,7 @@
 #define VISITORS_FACE_VISITOR_TYPE_1_TABLES_H_
 
 
+#include <string>
 #include <vector>
 
 #include <ft2build.h>
@@ -33,25 +34,13 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorType1Tables
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorType1Tables( void ) {}
-
-
-    FaceVisitorType1Tables( const FaceVisitorType1Tables& ) = delete;
-    FaceVisitorType1Tables& operator= (
-      const FaceVisitorType1Tables& ) = delete;
-
-
-    virtual
-    ~FaceVisitorType1Tables( void ) {}
 
 
     void
@@ -115,18 +104,18 @@
     // @See: `FT_Get_PS_Font_Value()'.
 
     static void
-    get_string( Unique_FT_Face&     face,
-                PS_Dict_Keys        key,
-                vector<FT_String>&  str );
+    get_string( Unique_FT_Face&          face,
+                PS_Dict_Keys             key,
+                std::vector<FT_String>&  str );
 
 
     // @See: `FT_Get_PS_Font_Value()'.
 
     static void
-    get_string( Unique_FT_Face&     face,
-                PS_Dict_Keys        key,
-                FT_UInt             index,
-                vector<FT_String>&  str );
+    get_string( Unique_FT_Face&          face,
+                PS_Dict_Keys             key,
+                FT_UInt                  index,
+                std::vector<FT_String>&  str );
 
 
     // @Description:
@@ -159,7 +148,7 @@
     loop_simple( Unique_FT_Face&         face,
                  size_t                  max_value_computed,
                  size_t                  max_value_static,
-                 string                  values_name,
+                 std::string             values_name,
                  PS_Dict_Keys            key,
                  T&                      value )
     {
@@ -180,13 +169,13 @@
     // @See: `FaceVisitorType1Tables::loop()'.
 
     static void
-    loop_string( Unique_FT_Face&     face,
-                 size_t              max_value_computed,
-                 size_t              max_value_static,
-                 string              values_name,
-                 PS_Dict_Keys        key,
-                 vector<FT_String>&  value );
+    loop_string( Unique_FT_Face&          face,
+                 size_t                   max_value_computed,
+                 size_t                   max_value_static,
+                 std::string              values_name,
+                 PS_Dict_Keys             key,
+                 std::vector<FT_String>&  value );
   };
-
+}
 
 #endif // VISITORS_FACE_VISITOR_TYPE_1_TABLES_H_

--- a/fuzzing/src/visitors/facevisitor-variants.cpp
+++ b/fuzzing/src/visitors/facevisitor-variants.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorVariants.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,17 +22,17 @@
 
 
   void
-  FaceVisitorVariants::
+  freetype::FaceVisitorVariants::
   run( Unique_FT_Face  face )
   {
     FT_Error  error;
 
-    FT_UInt32*         raw_selectors;
-    vector<FT_UInt32>  selectors;
+    FT_UInt32*              raw_selectors;
+    std::vector<FT_UInt32>  selectors;
 
-    FT_UInt32*      raw_chars;
-    set<FT_UInt32>  local_charcodes;
-    set<FT_UInt32>  global_charcodes;
+    FT_UInt32*           raw_chars;
+    std::set<FT_UInt32>  local_charcodes;
+    std::set<FT_UInt32>  global_charcodes;
 
     FT_Int   is_default;
     FT_UInt  glyph_index;
@@ -73,14 +73,14 @@
           break;
       }
 
-      for ( FT_UInt32  charcode : local_charcodes )
+      for ( auto  charcode : local_charcodes )
       {
         is_default = FT_Face_GetCharVariantIsDefault( face.get(),
                                                       charcode,
                                                       selector );
         LOG( INFO ) << "variant "
-                    << hex << "0x" << charcode << "/"
-                    << dec << selector
+                    << std::hex << "0x" << charcode << "/"
+                    << std::dec << selector
                     << " is default: " << is_default;
 
         glyph_index = FT_Face_GetCharVariantIndex( face.get(),
@@ -88,8 +88,8 @@
                                                    selector );
 
         LOG( INFO ) << "glpyh index of variant "
-                    << hex << "0x" << charcode << "/"
-                    << dec << selector << ": "
+                    << std::hex << "0x" << charcode << "/"
+                    << std::dec << selector << ": "
                     << glyph_index;
       }
     }
@@ -98,6 +98,6 @@
     // should check if this function works in tandem with
     // `FT_Face_GetCharsOfVariant' but this is not in the scope of fuzzers.
 
-    for ( FT_UInt32  charcode : global_charcodes )
+    for ( auto  charcode : global_charcodes )
       (void) FT_Face_GetVariantsOfChar( face.get(), charcode );
   }

--- a/fuzzing/src/visitors/facevisitor-variants.h
+++ b/fuzzing/src/visitors/facevisitor-variants.h
@@ -4,7 +4,7 @@
 //
 //   Drivers: all
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,24 +22,13 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorVariants
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorVariants( void ) {}
-
-
-    FaceVisitorVariants( const FaceVisitorVariants& ) = delete;
-    FaceVisitorVariants& operator= ( const FaceVisitorVariants& ) = delete;
-
-
-    virtual
-    ~FaceVisitorVariants( void ) {}
 
 
     void
@@ -53,6 +42,7 @@
     static const size_t  VARIANT_SELECTORS_MAX =  10;
     static const size_t  LOCAL_CHARCODES_MAX   =  50;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_VARIANTS_H_

--- a/fuzzing/src/visitors/facevisitor-windowsfnt.cpp
+++ b/fuzzing/src/visitors/facevisitor-windowsfnt.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of FaceVisitorWindowsFnt.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,7 +23,7 @@
 
 
   void
-  FaceVisitorWindowsFnt::
+  freetype::FaceVisitorWindowsFnt::
   run( Unique_FT_Face  face )
   {
     FT_Error             error;

--- a/fuzzing/src/visitors/facevisitor-windowsfnt.h
+++ b/fuzzing/src/visitors/facevisitor-windowsfnt.h
@@ -5,7 +5,7 @@
 //   Drivers:
 //     - Windows FNT
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -23,31 +23,20 @@
 #include "visitors/facevisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitorWindowsFnt
-  : public FaceVisitor
+    : public FaceVisitor
   {
   public:
-
-
-    FaceVisitorWindowsFnt( void ) {}
-
-
-    FaceVisitorWindowsFnt( const FaceVisitorWindowsFnt& ) = delete;
-    FaceVisitorWindowsFnt& operator= (
-      const FaceVisitorWindowsFnt& ) = delete;
-
-    
-    virtual
-    ~FaceVisitorWindowsFnt( void ) {}
 
 
     void
     run( Unique_FT_Face  face )
     override;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_WINDWOS_FNT_H_

--- a/fuzzing/src/visitors/facevisitor.h
+++ b/fuzzing/src/visitors/facevisitor.h
@@ -2,7 +2,7 @@
 //
 //   Base class of visitors of faces.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -15,27 +15,26 @@
 #ifndef VISITORS_FACE_VISITOR_H_
 #define VISITORS_FACE_VISITOR_H_
 
+
+#include <boost/core/noncopyable.hpp>
+
+#include <ft2build.h>
+#include FT_FREETYPE_H
+
 #include "utils/utils.h"
 
 
-  using namespace fuzzing;
-  using namespace std;
+namespace freetype {
 
 
   class FaceVisitor
+    : private boost::noncopyable
   {
   public:
 
 
-    FaceVisitor( void ) {}
-
-
-    FaceVisitor( const FaceVisitor& ) = delete;
-    FaceVisitor& operator= ( const FaceVisitor& ) = delete;
-
-
     virtual
-    ~FaceVisitor( void ) {}
+    ~FaceVisitor() = default;
 
 
     // @Description:
@@ -54,6 +53,7 @@
 
     FT_Library  library;
   };
+}
 
 
 #endif // VISITORS_FACE_VISITOR_H_

--- a/fuzzing/src/visitors/glyphvisitor-bitmap-handling.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-bitmap-handling.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphVisitorBitmapHandling.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,14 +22,18 @@
 #include "utils/logging.h"
 
 
-  const FT_Color  GlyphVisitorBitmapHandling::COLOUR_PINK =
+  const FT_Color
+  freetype::GlyphVisitorBitmapHandling::
+  COLOUR_PINK =
   {
     192, 168, 0, 128
   };
 
   // Offset vectors are in 26.6 fixed-point format.
 
-  const FT_Vector  GlyphVisitorBitmapHandling::SOURCE_OFFSET =
+  const FT_Vector
+  freetype::GlyphVisitorBitmapHandling::
+  SOURCE_OFFSET =
   {
     static_cast<FT_Pos>( 0x40 * -3.5 ),
     static_cast<FT_Pos>( 0x40 *  2.5 )
@@ -37,7 +41,7 @@
 
 
   void
-  GlyphVisitorBitmapHandling::
+  freetype::GlyphVisitorBitmapHandling::
   run( Unique_FT_Glyph  glyph )
   {
     FT_Error  error;
@@ -89,7 +93,7 @@
 
 
   bool
-  GlyphVisitorBitmapHandling::
+  freetype::GlyphVisitorBitmapHandling::
   extract_bitmap( Unique_FT_Glyph&  glyph,
                   FT_Bitmap&        bitmap )
   {
@@ -100,7 +104,7 @@
 
 
   bool
-  GlyphVisitorBitmapHandling::
+  freetype::GlyphVisitorBitmapHandling::
   copy_bitmap( FT_Library        library,
                const FT_Bitmap&  source,
                FT_Bitmap&        target )
@@ -116,7 +120,7 @@
 
 
   void
-  GlyphVisitorBitmapHandling::
+  freetype::GlyphVisitorBitmapHandling::
   embolden( FT_Library  library,
             FT_Bitmap&  bitmap,
             FT_Pos      xStrength,
@@ -133,7 +137,7 @@
 
 
   void
-  GlyphVisitorBitmapHandling::
+  freetype::GlyphVisitorBitmapHandling::
   blend( FT_Library        library,
          const FT_Bitmap&  source,
          FT_Bitmap&        target )
@@ -161,7 +165,7 @@
 
     
   void
-  GlyphVisitorBitmapHandling::
+  freetype::GlyphVisitorBitmapHandling::
   convert( Unique_FT_Glyph&  glyph,
            FT_Bitmap&        bitmap,
            FT_Int            alignment )

--- a/fuzzing/src/visitors/glyphvisitor-bitmap-handling.h
+++ b/fuzzing/src/visitors/glyphvisitor-bitmap-handling.h
@@ -2,7 +2,7 @@
 //
 //   Invoke API functions that deal with bitmap handling.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,22 +22,13 @@
 #include "visitors/glyphvisitor.h"
 
 
+namespace freetype {
+
+
   class GlyphVisitorBitmapHandling
-  : public GlyphVisitor
+    : public GlyphVisitor
   {
   public:
-
-
-    GlyphVisitorBitmapHandling( void ) {}
-
-
-    GlyphVisitorBitmapHandling( const GlyphVisitorBitmapHandling& ) = delete;
-    GlyphVisitorBitmapHandling& operator= (
-      const GlyphVisitorBitmapHandling& ) = delete;
-
-
-    virtual
-    ~GlyphVisitorBitmapHandling( void ) {}
 
 
     void
@@ -81,6 +72,7 @@
              FT_Bitmap&        bitmap,
              FT_Int            alignment );
   };
+}
 
 
 #endif // VISITORS_GLYPH_VISITOR_BITMAP_HANDLING_H_

--- a/fuzzing/src/visitors/glyphvisitor-cbox.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-cbox.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphVisitorCBox.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -20,7 +20,7 @@
 
 
   void
-  GlyphVisitorCBox::
+  freetype::GlyphVisitorCBox::
   run( Unique_FT_Glyph  glyph )
   {
     assert( glyph != nullptr );
@@ -34,10 +34,10 @@
 
 
   void
-  GlyphVisitorCBox::
+  freetype::GlyphVisitorCBox::
   query_cbox( const Unique_FT_Glyph&  glyph,
               FT_Glyph_BBox_Mode      bbox_mode,
-              const string&           name )
+              const std::string&      name )
   {
     FT_BBox   acbox;
 

--- a/fuzzing/src/visitors/glyphvisitor-cbox.h
+++ b/fuzzing/src/visitors/glyphvisitor-cbox.h
@@ -2,7 +2,7 @@
 //
 //   Query glyphs' control boxes.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -16,27 +16,18 @@
 #define VISITORS_GLYPH_VISITOR_CBOX_H_
 
 
+#include <string>
+
 #include "visitors/glyphvisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class GlyphVisitorCBox
-  : public GlyphVisitor
+    : public GlyphVisitor
   {
   public:
-
-
-    GlyphVisitorCBox( void ) {}
-
-
-    GlyphVisitorCBox( const GlyphVisitorCBox& ) = delete;
-    GlyphVisitorCBox& operator= ( const GlyphVisitorCBox& ) = delete;
-
-
-    virtual
-    ~GlyphVisitorCBox( void ) {}
 
 
     void
@@ -50,8 +41,9 @@
     void
     query_cbox( const Unique_FT_Glyph&  glyph,
                 FT_Glyph_BBox_Mode      bbox_mode,
-                const string&           name );
+                const std::string&      name );
   };
+}
 
 
 #endif // VISITORS_GLYPH_VISITOR_CBOX_H_

--- a/fuzzing/src/visitors/glyphvisitor-outlines.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-outlines.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphVisitorOutlines.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -22,8 +22,8 @@
 #include "utils/logging.h"
 
 
-  GlyphVisitorOutlines::
-  GlyphVisitorOutlines( void )
+  freetype::GlyphVisitorOutlines::
+  GlyphVisitorOutlines()
   {
     (void) callbacks.emplace_back( reverse    );
     (void) callbacks.emplace_back( embolden_1 );
@@ -34,7 +34,7 @@
 
 
   void
-  GlyphVisitorOutlines::
+  freetype::GlyphVisitorOutlines::
   run( Unique_FT_Glyph  glyph )
   {
     FT_Error     error;
@@ -73,7 +73,7 @@
 
 
   void
-  GlyphVisitorOutlines::
+  freetype::GlyphVisitorOutlines::
   reverse( FT_Outline&  outline )
   {
     LOG( INFO ) << "reversing outline";
@@ -83,7 +83,7 @@
 
 
   void
-  GlyphVisitorOutlines::
+  freetype::GlyphVisitorOutlines::
   embolden( FT_Outline&  outline,
             FT_Pos       strength )
   {
@@ -98,7 +98,7 @@
 
 
   void
-  GlyphVisitorOutlines::
+  freetype::GlyphVisitorOutlines::
   embolden( FT_Outline&  outline,
             FT_Pos       xstrength,
             FT_Pos       ystrength )
@@ -115,7 +115,7 @@
 
 
   void
-  GlyphVisitorOutlines::
+  freetype::GlyphVisitorOutlines::
   embolden_1( FT_Outline&  outline )
   {
     // Note: the strength is in 26.6 format.
@@ -124,7 +124,7 @@
 
 
   void
-  GlyphVisitorOutlines::
+  freetype::GlyphVisitorOutlines::
   embolden_2( FT_Outline&  outline )
   {
     // Note: the strength is in 26.6 format.
@@ -133,7 +133,7 @@
 
 
   void
-  GlyphVisitorOutlines::
+  freetype::GlyphVisitorOutlines::
   embolden_3( FT_Outline&  outline )
   {
     // Note: the strength is in 26.6 format.
@@ -141,7 +141,7 @@
   }
 
   void
-  GlyphVisitorOutlines::
+  freetype::GlyphVisitorOutlines::
   embolden_4( FT_Outline&  outline )
   {
     // Note: the strength is in 26.6 format.

--- a/fuzzing/src/visitors/glyphvisitor-outlines.h
+++ b/fuzzing/src/visitors/glyphvisitor-outlines.h
@@ -11,7 +11,7 @@
 //     - Type 1
 //     - Type 42
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -31,24 +31,16 @@
 #include "visitors/glyphvisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class GlyphVisitorOutlines
-  : public GlyphVisitor
+    : public GlyphVisitor
   {
   public:
 
 
-    GlyphVisitorOutlines( void );
-
-
-    GlyphVisitorOutlines( const GlyphVisitorOutlines& ) = delete;
-    GlyphVisitorOutlines& operator= ( const GlyphVisitorOutlines& ) = delete;
-
-
-    virtual
-    ~GlyphVisitorOutlines( void ) {}
+    GlyphVisitorOutlines();
 
 
     void
@@ -61,7 +53,7 @@
 
     typedef void  (*OutlineFunc)( FT_Outline& );
 
-    vector<OutlineFunc>  callbacks;
+    std::vector<OutlineFunc>  callbacks;
 
 
     // @Description:
@@ -115,6 +107,7 @@
     static void
     embolden_4( FT_Outline&  outline );
   };
+}
 
 
 #endif // VISITORS_GLYPH_VISITOR_OUTLINES_H_

--- a/fuzzing/src/visitors/glyphvisitor-transform.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-transform.cpp
@@ -2,7 +2,7 @@
 //
 //   Implementation of GlyphVisitorTransform.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -20,7 +20,7 @@
 
 
   void
-  GlyphVisitorTransform::
+  freetype::GlyphVisitorTransform::
   run( Unique_FT_Glyph  glyph )
   {
     FT_Error  error;
@@ -52,7 +52,7 @@
 
 
   void
-  GlyphVisitorTransform::
+  freetype::GlyphVisitorTransform::
   transform( const Unique_FT_Glyph&  glyph,
              FT_Matrix*              matrix,
              FT_Vector*              delta )

--- a/fuzzing/src/visitors/glyphvisitor-transform.h
+++ b/fuzzing/src/visitors/glyphvisitor-transform.h
@@ -2,7 +2,7 @@
 //
 //   Visitor that transform a given glyph.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -19,25 +19,13 @@
 #include "visitors/glyphvisitor.h"
 
 
-  using namespace std;
+namespace freetype {
 
 
   class GlyphVisitorTransform
-  : public GlyphVisitor
+    : public GlyphVisitor
   {
   public:
-
-
-    GlyphVisitorTransform( void ) {}
-
-
-    GlyphVisitorTransform( const GlyphVisitorTransform& ) = delete;
-    GlyphVisitorTransform& operator= (
-      const GlyphVisitorTransform& ) = delete;
-
-
-    virtual
-    ~GlyphVisitorTransform( void ) {}
 
 
     void
@@ -53,6 +41,7 @@
                FT_Matrix*              matrix,
                FT_Vector*              delta );
   };
+}
 
 
 #endif // VISITORS_GLYPH_VISITOR_TRANSFORM_H_

--- a/fuzzing/src/visitors/glyphvisitor.h
+++ b/fuzzing/src/visitors/glyphvisitor.h
@@ -2,7 +2,7 @@
 //
 //   Base class of visitors of glyphs.
 //
-// Copyright 2018 by
+// Copyright 2018-2019 by
 // Armin Hasitzka.
 //
 // This file is part of the FreeType project, and may only be used,
@@ -18,25 +18,20 @@
 
 #include "utils/utils.h"
 
+#include <boost/core/noncopyable.hpp>
 
-  using namespace fuzzing;
-  using namespace std;
+
+namespace freetype {
 
 
   class GlyphVisitor
+    : private boost::noncopyable
   {
   public:
 
 
-    GlyphVisitor( void ) {}
-
-
-    GlyphVisitor( const GlyphVisitor& ) = delete;
-    GlyphVisitor& operator= ( const GlyphVisitor& ) = delete;
-
-
     virtual
-    ~GlyphVisitor( void ) {}
+    ~GlyphVisitor() = default;
 
 
     // @Description:
@@ -49,6 +44,7 @@
     virtual void
     run( Unique_FT_Glyph  glyph ) = 0;
   };
+}
 
 
 #endif // VISITORS_GLYPH_VISITOR_H_


### PR DESCRIPTION
- Remove `using namespace std;`.
- Use `boost::noncopyable` as common base class.
- Wrap everything into `namespace freetype`.
- Minor code cleanups along the way.