### PR TITLE
Fix Travis CI Build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,23 +16,16 @@ matrix:
     - os: linux
       language: cpp
       compiler: clang
-      addons:
-        apt:
-          sources: llvm-toolchain-trusty-5.0
-          packages: clang-5.0
       env:
         - TRAVIS_CI_ROW="regression-suite"
-        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0"
     - os: linux
       sudo: required
       services: docker
       env:
         - TRAVIS_CI_ROW="oss-fuzz-build"
-        - MATRIX_EVAL=
 
 before_install:
   - sudo apt-get -qq update && sudo apt-get install -y autoconf cmake libtool
-  - eval "${MATRIX_EVAL}"
 
 script:
   - bash fuzzing/scripts/run-travis-ci.sh


### PR DESCRIPTION
- The automatic update to Xenial ships Clang 7 by default;  downgrade to Clang 5 fails the build.