### PR TITLE
Use `la_int64_t*` instead of `off_t*` ...

### DIFF
--- a/fuzzing/src/utils/tarreader.cpp
+++ b/fuzzing/src/utils/tarreader.cpp
@@ -63,7 +63,7 @@
 
       const FT_Byte*  buffer;
       size_t          buffer_size;
-      off_t           offset;
+      la_int64_t      offset;
 
       std::vector<FT_Byte>  entry_data;
 


### PR DESCRIPTION
when invoking `archive_read_data_block`.

... not exactly sure why I used `off_t*` in first place.