### PR TITLE
Define HAVE_ARCHIVE to allow building without libarchive

### DIFF
--- a/fuzzing/src/iterators/faceloaditerator.cpp
+++ b/fuzzing/src/iterators/faceloaditerator.cpp
@@ -46,6 +46,7 @@
     (void) face_loader->set_raw_bytes( data, size );
   }
 
+
 #ifdef HAVE_ARCHIVE
   void
   freetype::FaceLoadIterator::

--- a/fuzzing/src/iterators/faceloaditerator.cpp
+++ b/fuzzing/src/iterators/faceloaditerator.cpp
@@ -46,7 +46,7 @@
     (void) face_loader->set_raw_bytes( data, size );
   }
 
-
+#ifdef HAVE_ARCHIVE
   void
   freetype::FaceLoadIterator::
   set_data_is_tar_archive( bool  is_tar_archive )
@@ -54,6 +54,7 @@
     assert( face_loader != nullptr );
     (void) face_loader->set_data_is_tar_archive( is_tar_archive );
   }
+#endif
 
 
   void

--- a/fuzzing/src/iterators/faceloaditerator.h
+++ b/fuzzing/src/iterators/faceloaditerator.h
@@ -61,11 +61,12 @@ namespace freetype {
                    size_t          size );
 
 
+#ifdef HAVE_ARCHIVE
     // @See: FaceLoader::set_data_is_tar_archive()
 
     void
     set_data_is_tar_archive( bool  is_tar_archive );
-    
+#endif
 
     // @Description:
     //   Add a face visitor that is called once, with the first loaded face.

--- a/fuzzing/src/targets/CMakeLists.txt
+++ b/fuzzing/src/targets/CMakeLists.txt
@@ -88,7 +88,8 @@ add_library(fuzztargets
 
 target_compile_definitions(fuzztargets
   PRIVATE
-  "${LOGGER_NAME}" HAVE_ARCHIVE)
+  "${LOGGER_NAME}"
+  HAVE_ARCHIVE)
 
 if("${FUZZ_TARGET_TYPE}" STREQUAL "libfuzzer")
 

--- a/fuzzing/src/targets/CMakeLists.txt
+++ b/fuzzing/src/targets/CMakeLists.txt
@@ -88,7 +88,7 @@ add_library(fuzztargets
 
 target_compile_definitions(fuzztargets
   PRIVATE
-  "${LOGGER_NAME}")
+  "${LOGGER_NAME}" HAVE_ARCHIVE)
 
 if("${FUZZ_TARGET_TYPE}" STREQUAL "libfuzzer")
 

--- a/fuzzing/src/targets/FaceFuzzTarget.cpp
+++ b/fuzzing/src/targets/FaceFuzzTarget.cpp
@@ -57,6 +57,7 @@
   }
 
 
+#ifdef HAVE_ARCHIVE
   void
   freetype::FaceFuzzTarget::
   set_data_is_tar_archive( bool  is_tar_archive )
@@ -64,6 +65,7 @@
     assert( face_load_iterator != nullptr );
     (void) face_load_iterator->set_data_is_tar_archive( is_tar_archive );
   }
+#endif
 
 
   bool

--- a/fuzzing/src/targets/FaceFuzzTarget.h
+++ b/fuzzing/src/targets/FaceFuzzTarget.h
@@ -74,6 +74,7 @@ namespace freetype {
     set_data_is_tar_archive( bool  is_tar_archive );
 #endif
 
+
     // @Description:
     //   Set a FreeType property via `FT_Property_Set'.
     //

--- a/fuzzing/src/targets/FaceFuzzTarget.h
+++ b/fuzzing/src/targets/FaceFuzzTarget.h
@@ -67,11 +67,12 @@ namespace freetype {
     set_supported_font_format( FaceLoader::FontFormat  format );
 
 
+#ifdef HAVE_ARCHIVE
     // @See: `FaceLoader::set_data_is_tar_archive()'
 
     void
     set_data_is_tar_archive( bool  is_tar_archive );
-
+#endif
 
     // @Description:
     //   Set a FreeType property via `FT_Property_Set'.

--- a/fuzzing/src/utils/faceloader.cpp
+++ b/fuzzing/src/utils/faceloader.cpp
@@ -60,22 +60,25 @@
 
     (void) files.clear();
 
+#ifdef HAVE_ARCHIVE
     if ( data_is_tar_archive == true )
       (void) tarreader.extract_data( data, size );
     else
+#endif
       (void) files.emplace_back( data, data + size );
 
     num_faces     = -1;
     num_instances = -1;
   }
 
-
+#ifdef HAVE_ARCHIVE
   void
   freetype::FaceLoader::
   set_data_is_tar_archive( bool  is_tar_archive )
   {
     data_is_tar_archive = is_tar_archive;
   }
+#endif
 
 
   void

--- a/fuzzing/src/utils/faceloader.h
+++ b/fuzzing/src/utils/faceloader.h
@@ -98,6 +98,7 @@ namespace freetype {
                    size_t          size );
 
 
+#ifdef HAVE_ARCHIVE
     // @Description:
     //   Choose whether this target should treat incoming data as a tar
     //   archive or as a plain font file.  Mind that this only makes sense
@@ -109,6 +110,7 @@ namespace freetype {
 
     void
     set_data_is_tar_archive( bool  is_tar_archive );
+#endif
 
 
     void
@@ -165,7 +167,9 @@ namespace freetype {
     FontFormat   supported_font_format        = FontFormat::NONE;
     std::string  supported_font_format_string = "";
 
+#ifdef HAVE_ARCHIVE
     bool  data_is_tar_archive = false;
+#endif
 
     FT_Long  num_faces  = -1;
     FT_Long  face_index =  0;

--- a/fuzzing/src/utils/utils.h
+++ b/fuzzing/src/utils/utils.h
@@ -28,18 +28,18 @@
 
 #include <memory>
 
-#include <archive.h>
-
 #include <ft2build.h>
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 
 
+struct archive;
+
 namespace freetype
 {
 
-  typedef std::unique_ptr<struct archive,
-                          decltype( archive_read_free )*>  Unique_Archive;
+  typedef std::unique_ptr<archive,
+                          int( * )( archive* ) >  Unique_Archive;
 
   typedef std::unique_ptr<FT_FaceRec,
                           decltype( FT_Done_Face )*>  Unique_FT_Face;

--- a/fuzzing/src/utils/utils.h
+++ b/fuzzing/src/utils/utils.h
@@ -35,6 +35,7 @@
 
 struct archive;
 
+
 namespace freetype
 {
 


### PR DESCRIPTION
Redefine std::unique_ptr helper Unique_Archive based on forward
declaration, define HAVE_ARCHIVE in CMakeLists.txt and use it
for conditional compilation of tar related setters.