### PR TITLE
Build fix when HAVE_ARCHIVE not available

### DIFF
--- a/fuzzing/src/targets/font-drivers/type1-render.cpp
+++ b/fuzzing/src/targets/font-drivers/type1-render.cpp
@@ -79,5 +79,7 @@
 
     (void) set_iterator( std::move( fli ) );
 
+#ifdef HAVE_ARCHIVE
     (void) set_data_is_tar_archive( false );
+#endif
   }

--- a/fuzzing/src/targets/font-drivers/type1.cpp
+++ b/fuzzing/src/targets/font-drivers/type1.cpp
@@ -82,5 +82,7 @@
 
     (void) set_iterator( std::move( fli ) );
 
+#ifdef HAVE_ARCHIVE
     (void) set_data_is_tar_archive( false );
+#endif
   }


### PR DESCRIPTION
Needed for building the CID and CIDType1 fuzzers
as part of Chromium fuzzing.