### PR TITLE
Fix unused variable build warnings/errors

### DIFF
--- a/fuzzing/src/visitors/facevisitor-variants.cpp
+++ b/fuzzing/src/visitors/facevisitor-variants.cpp
@@ -25,8 +25,6 @@
   freetype::FaceVisitorVariants::
   run( Unique_FT_Face  face )
   {
-    FT_Error  error;
-
     FT_UInt32*              raw_selectors;
     std::vector<FT_UInt32>  selectors;
 

--- a/fuzzing/src/visitors/glyphvisitor-bitmap-handling.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-bitmap-handling.cpp
@@ -44,8 +44,6 @@
   freetype::GlyphVisitorBitmapHandling::
   run( Unique_FT_Glyph  glyph )
   {
-    FT_Error  error;
-
     FT_Library  library;
     FT_Bitmap   bitmap_1;
     FT_Bitmap   bitmap_2;

--- a/fuzzing/src/visitors/glyphvisitor-transform.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-transform.cpp
@@ -23,8 +23,6 @@
   freetype::GlyphVisitorTransform::
   run( Unique_FT_Glyph  glyph )
   {
-    FT_Error  error;
-
     FT_Matrix  matrix;
     FT_Vector  delta;
 


### PR DESCRIPTION
Remove a couple of unused FT_Errors, those showed up
when building as part of Chromium and would currently
require error suppression for a successful build.