### PR TITLE
Fix unitialized value num_subrs and sign comparison issues

### DIFF
--- a/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
+++ b/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
@@ -56,7 +56,7 @@
 
       if ( error == 0 )
       {
-        for ( auto i = 0; i < master.num_axis; i++ )
+        for ( FT_UInt i = 0; i < master.num_axis; i++ )
           coords_mm_design.push_back( ( master.axis[i].minimum +
                                         master.axis[i].maximum ) / 2 );
 
@@ -79,7 +79,7 @@
     }
 
     // Select arbitrary coordinates:
-    for ( auto  i = 0;
+    for ( FT_UInt  i = 0;
           i < var->num_axis &&
             i < AXIS_INDEX_MAX;
           i++ )
@@ -125,7 +125,7 @@
                         "FT_Get_Var_Blend_Coordinates",
                         FT_Get_Var_Blend_Coordinates );
 
-    for ( auto  i = 0; i < var->num_axis; i++ )
+    for ( FT_UInt  i = 0; i < var->num_axis; i++ )
     {
       FT_UInt flags;
 
@@ -137,7 +137,7 @@
         << "flags of axis " << ( i + 1 ) << ": " << std::hex << "0x" << flags;
     }
 
-    for ( auto  i = 0; i < var->num_namedstyles; i++ )
+    for ( FT_UInt  i = 0; i < var->num_namedstyles; i++ )
     {
       // TODO: extract the name (strid + psid).
       LOG( INFO ) << "setting named instance " << ( i + 1 );

--- a/fuzzing/src/visitors/facevisitor-type1tables.cpp
+++ b/fuzzing/src/visitors/facevisitor-type1tables.cpp
@@ -41,7 +41,7 @@
     std::vector<FT_String>  string_buffer;
 
     FT_Int   num_char_strings;
-    FT_Int   num_subrs;
+    FT_Int   num_subrs = 0;
     FT_Byte  num_blue_values;
     FT_Byte  num_other_blues;
     FT_Byte  num_family_blues;
@@ -258,7 +258,7 @@
                PS_Dict_Keys             key,
                std::vector<FT_String>&  value )
   {
-    for ( auto  index = 0;
+    for ( size_t  index = 0;
           index < max_value_computed &&
             index < max_value_static;
           index++ )

--- a/fuzzing/src/visitors/facevisitor-type1tables.h
+++ b/fuzzing/src/visitors/facevisitor-type1tables.h
@@ -152,7 +152,7 @@ namespace freetype {
                  PS_Dict_Keys            key,
                  T&                      value )
     {
-      for ( auto  index = 0;
+      for ( size_t  index = 0;
             index < max_value_computed &&
               index < max_value_static;
             index++ )


### PR DESCRIPTION
In the Chromium build, clang complains about num_subrs being
uninitialized. Fix this to avoid the compiler erroring out on this
variable. In addition, use explict types in a few place to avoid
signed/unsigned comparison issues.