### PR TITLE
Include colrv1 in script preparing fuzzer corpora

### DIFF
--- a/fuzzing/scripts/prepare-oss-fuzz.sh
+++ b/fuzzing/scripts/prepare-oss-fuzz.sh
@@ -33,6 +33,8 @@ fuzzers=(
     "cidtype1-render"
     "cidtype1-render-ftengine"
 
+    "colrv1"
+
     "pcf"
     "pcf-render"
 


### PR DESCRIPTION
Hopefully addresses no coverage being reported for the colrv1 fuzzer so
far in oss-fuzz.