### PR TITLE
Track visited FT_OpaquePaint in order to avoid cycles

### DIFF
--- a/fuzzing/src/visitors/facevisitor-colrv1.cpp
+++ b/fuzzing/src/visitors/facevisitor-colrv1.cpp
@@ -23,18 +23,22 @@
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
+
 template<> struct std::hash<FT_OpaquePaint>
 {
 
 
   std::size_t
-  operator()( FT_OpaquePaint const& p ) const
+  operator()( const FT_OpaquePaint&  p ) const
   {
     std::size_t h1 = std::hash<FT_Byte*>{}( p.p );
     std::size_t h2 = std::hash<FT_Bool>{}( p.insert_root_transform );
+
+
     return h1 ^ (h2 << 1);
   }
 };
+
 
 template<> struct std::equal_to<FT_OpaquePaint>
 {
@@ -44,42 +48,49 @@ template<> struct std::equal_to<FT_OpaquePaint>
   operator()( const FT_OpaquePaint&  lhs,
               const FT_OpaquePaint&  rhs ) const
   {
-    return lhs.p == rhs.p && lhs.insert_root_transform == rhs.insert_root_transform;
+    return lhs.p == rhs.p &&
+           lhs.insert_root_transform == rhs.insert_root_transform;
   }
 };
+
 
 namespace {
 
 
-  constexpr unsigned long  MAX_TRAVERSE_GLYPHS = 5;
-
   using VisitedSet = std::unordered_set<FT_OpaquePaint>;
 
 
+  constexpr unsigned long  MAX_TRAVERSE_GLYPHS = 5;
+
+
   class ScopedSetInserter
-    : private freetype::noncopyable {
-   public:
+    : private freetype::noncopyable
+  {
+  public:
 
 
     ScopedSetInserter( VisitedSet*     set,
                        FT_OpaquePaint  paint)
       : visited_set( set ),
-        p( paint ) {
+        p( paint )
+    {
 
 
       visited_set->insert(p);
     }
 
 
-    ~ScopedSetInserter() {
+    ~ScopedSetInserter()
+    {
       visited_set->erase(p);
     }
 
-   private:
+
+  private:
 
 
-    VisitedSet* visited_set;
-    FT_OpaquePaint p;
+    VisitedSet*     visited_set;
+    FT_OpaquePaint  p;
   };
 
 
@@ -240,13 +251,16 @@ namespace {
 
     bool  traverse_result = true;
 
+
     if ( visited_set->find( opaque_paint ) != visited_set->end() )
     {
       LOG( ERROR ) << "Paint cycle detected, aborting.";
       return false;
     }
 
-    ScopedSetInserter scoped_set_inserter( visited_set, opaque_paint );
+
+    ScopedSetInserter  scoped_set_inserter( visited_set, opaque_paint );
+
 
     if ( !FT_Get_Paint( face, opaque_paint, &paint ) )
     {

--- a/fuzzing/src/visitors/facevisitor-colrv1.cpp
+++ b/fuzzing/src/visitors/facevisitor-colrv1.cpp
@@ -16,17 +16,71 @@
 #include "visitors/facevisitor-colrv1.h"
 
 #include <cassert>
+#include <unordered_set>
 
 #include "utils/logging.h"
 
 #include <ft2build.h>
 #include FT_FREETYPE_H
 
+template<> struct std::hash<FT_OpaquePaint>
+{
+
+
+  std::size_t
+  operator()( FT_OpaquePaint const& p ) const
+  {
+    std::size_t h1 = std::hash<FT_Byte*>{}( p.p );
+    std::size_t h2 = std::hash<FT_Bool>{}( p.insert_root_transform );
+    return h1 ^ (h2 << 1);
+  }
+};
+
+template<> struct std::equal_to<FT_OpaquePaint>
+{
+
+
+  bool
+  operator()( const FT_OpaquePaint&  lhs,
+              const FT_OpaquePaint&  rhs ) const
+  {
+    return lhs.p == rhs.p && lhs.insert_root_transform == rhs.insert_root_transform;
+  }
+};
 
 namespace {
 
 
   constexpr unsigned long  MAX_TRAVERSE_GLYPHS = 5;
+
+  using VisitedSet = std::unordered_set<FT_OpaquePaint>;
+
+
+  class ScopedSetInserter
+    : private freetype::noncopyable {
+   public:
+
+
+    ScopedSetInserter( VisitedSet*     set,
+                       FT_OpaquePaint  paint)
+      : visited_set( set ),
+        p( paint ) {
+
+
+      visited_set->insert(p);
+    }
+
+
+    ~ScopedSetInserter() {
+      visited_set->erase(p);
+    }
+
+   private:
+
+
+    VisitedSet* visited_set;
+    FT_OpaquePaint p;
+  };
 
 
   bool colrv1_start_glyph( const FT_Face&           ft_face,
@@ -179,12 +233,20 @@ namespace {
 
 
   bool colrv1_traverse_paint( FT_Face         face,
-                              FT_OpaquePaint  opaque_paint )
+                              FT_OpaquePaint  opaque_paint,
+                              VisitedSet*     visited_set )
   {
     FT_COLR_Paint  paint;
 
     bool  traverse_result = true;
 
+    if ( visited_set->find( opaque_paint ) != visited_set->end() )
+    {
+      LOG( ERROR ) << "Paint cycle detected, aborting.";
+      return false;
+    }
+
+    ScopedSetInserter scoped_set_inserter( visited_set, opaque_paint );
 
     if ( !FT_Get_Paint( face, opaque_paint, &paint ) )
     {
@@ -209,14 +271,18 @@ namespace {
       while ( FT_Get_Paint_Layers( face,
                                    &layer_iterator,
                                    &opaque_paint_fetch ) )
-        colrv1_traverse_paint( face, opaque_paint_fetch );
+        colrv1_traverse_paint( face,
+                               opaque_paint_fetch,
+                               visited_set );
 
       break;
     }
 
     case FT_COLR_PAINTFORMAT_GLYPH:
       colrv1_draw_paint( face, paint );
-      traverse_result = colrv1_traverse_paint( face, paint.u.glyph.paint );
+      traverse_result = colrv1_traverse_paint( face,
+                                               paint.u.glyph.paint,
+                                               visited_set );
       break;
 
     case FT_COLR_PAINTFORMAT_COLR_GLYPH:
@@ -232,23 +298,29 @@ namespace {
     case FT_COLR_PAINTFORMAT_TRANSLATE:
       colrv1_draw_paint( face, paint );
       traverse_result = colrv1_traverse_paint( face,
-                                               paint.u.translate.paint );
+                                               paint.u.translate.paint,
+                                               visited_set );
       break;
 
     case FT_COLR_PAINTFORMAT_TRANSFORMED:
       colrv1_draw_paint( face, paint );
       traverse_result = colrv1_traverse_paint( face,
-                                               paint.u.transformed.paint );
+                                               paint.u.transformed.paint,
+                                               visited_set );
       break;
 
     case FT_COLR_PAINTFORMAT_ROTATE:
       colrv1_draw_paint( face, paint );
-      traverse_result = colrv1_traverse_paint( face, paint.u.rotate.paint );
+      traverse_result = colrv1_traverse_paint( face,
+                                               paint.u.rotate.paint,
+                                               visited_set );
       break;
 
     case FT_COLR_PAINTFORMAT_SKEW:
       colrv1_draw_paint( face, paint );
-      traverse_result = colrv1_traverse_paint( face, paint.u.skew.paint );
+      traverse_result = colrv1_traverse_paint( face,
+                                               paint.u.skew.paint,
+                                               visited_set );
       break;
 
     case FT_COLR_PAINTFORMAT_COMPOSITE:
@@ -257,10 +329,12 @@ namespace {
                   << " composite_mode " << paint.u.composite.composite_mode;
 
       traverse_result = colrv1_traverse_paint( face,
-                                               paint.u.composite.backdrop_paint );
+                                               paint.u.composite.backdrop_paint,
+                                               visited_set );
       traverse_result =
         traverse_result && colrv1_traverse_paint( face,
-                                                  paint.u.composite.source_paint );
+                                                  paint.u.composite.source_paint,
+                                                  visited_set );
         break;
     }
 
@@ -298,8 +372,9 @@ namespace {
                                    root_transform,
                                    &opaque_paint ) )
     {
+      VisitedSet visited_set;
       has_colrv1_layers = true;
-      colrv1_traverse_paint( ft_face, opaque_paint );
+      colrv1_traverse_paint( ft_face, opaque_paint, &visited_set );
     }
 
     return has_colrv1_layers;

--- a/fuzzing/src/visitors/facevisitor-colrv1.cpp
+++ b/fuzzing/src/visitors/facevisitor-colrv1.cpp
@@ -69,27 +69,27 @@ namespace {
   public:
 
 
-    ScopedSetInserter( VisitedSet*     set,
+    ScopedSetInserter( VisitedSet&     set,
                        FT_OpaquePaint  paint)
       : visited_set( set ),
         p( paint )
     {
 
 
-      visited_set->insert(p);
+      visited_set.insert(p);
     }
 
 
     ~ScopedSetInserter()
     {
-      visited_set->erase(p);
+      visited_set.erase(p);
     }
 
 
   private:
 
 
-    VisitedSet*     visited_set;
+    VisitedSet&     visited_set;
     FT_OpaquePaint  p;
   };
 
@@ -245,14 +245,14 @@ namespace {
 
   bool colrv1_traverse_paint( FT_Face         face,
                               FT_OpaquePaint  opaque_paint,
-                              VisitedSet*     visited_set )
+                              VisitedSet&     visited_set )
   {
     FT_COLR_Paint  paint;
 
     bool  traverse_result = true;
 
 
-    if ( visited_set->find( opaque_paint ) != visited_set->end() )
+    if ( visited_set.find( opaque_paint ) != visited_set.end() )
     {
       LOG( ERROR ) << "Paint cycle detected, aborting.";
       return false;
@@ -388,7 +388,7 @@ namespace {
     {
       VisitedSet visited_set;
       has_colrv1_layers = true;
-      colrv1_traverse_paint( ft_face, opaque_paint, &visited_set );
+      colrv1_traverse_paint( ft_face, opaque_paint, visited_set );
     }
 
     return has_colrv1_layers;


### PR DESCRIPTION
This is done on the application side, as FreeType would otherwise need
to be aware of traversals, which would carry too much state for how the
API is designed. Documentation in FreeType will be updated accordingly.

Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=33499.