### PR TITLE
Make --rebuild work correctly again.

### DIFF
--- a/fuzzing/scripts/build-fuzzers.sh
+++ b/fuzzing/scripts/build-fuzzers.sh
@@ -21,13 +21,15 @@ cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts'
 # which would cause CMake's setup process to fail.  See
 # `fuzzing/src/fuzzing/CMakeLists.txt' for details.
 
-bash "build/libarchive.sh"
+# Each project must be listed after any project it depends on.
 bash "build/zlib.sh"
-bash "build/libpng.sh"
-bash "build/brotli.sh"
 bash "build/bzip2.sh"
+bash "build/libarchive.sh"
+bash "build/brotli.sh"
+bash "build/libpng.sh"
 bash "build/freetype.sh"
 bash "build/libcxx.sh"
+#bash "build/glog.sh"
 bash "build/targets.sh"
 
 cd "${dir}"

--- a/fuzzing/scripts/build/bzip2.sh
+++ b/fuzzing/scripts/build/bzip2.sh
@@ -26,6 +26,9 @@ if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
     git rev-parse HEAD
 fi
 
-make -j$( nproc )
+if [[ -f "${path_to_src}/Makefile" ]]; then
+  cd ${path_to_src}
+  make -j$( nproc )
+fi
 
 cd "${dir}"

--- a/fuzzing/scripts/build/freetype.sh
+++ b/fuzzing/scripts/build/freetype.sh
@@ -59,9 +59,8 @@ if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
        --without-harfbuzz
 fi
 
-cd "${path_to_freetype}"
-
-if [[ -f "Makefile" ]]; then
+if [[ -f "${path_to_freetype}/Makefile" ]]; then
+    cd "${path_to_freetype}"
     make -j$( nproc )
 fi
 

--- a/fuzzing/scripts/build/libarchive.sh
+++ b/fuzzing/scripts/build/libarchive.sh
@@ -61,9 +61,8 @@ if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
        --without-expat
 fi
 
-cd "${path_to_src}"
-
-if [[ -f "Makefile" ]]; then
+if [[ -f "${path_to_src}/Makefile" ]]; then
+    cd "${path_to_src}"
     make -j$( nproc )
 fi
 

--- a/fuzzing/scripts/build/libpng.sh
+++ b/fuzzing/scripts/build/libpng.sh
@@ -56,7 +56,7 @@ if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
                     --disable-shared
 fi
 
-if [[ -d "${path_to_build}" ]]; then
+if [[ -f "${path_to_build}/Makefile" ]]; then
     cd "${path_to_build}"
     make -j$(nproc) clean
     make -j$(nproc)

--- a/fuzzing/scripts/build/zlib.sh
+++ b/fuzzing/scripts/build/zlib.sh
@@ -38,7 +38,7 @@ if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
                    --static
 fi
 
-if [[ -d "${path_to_build}" ]]; then
+if [[ -f "${path_to_build}/Makefile" ]]; then
     cd "${path_to_build}"
     make -j$( nproc ) clean
     make -j$( nproc )

--- a/fuzzing/scripts/custom-build.sh
+++ b/fuzzing/scripts/custom-build.sh
@@ -68,6 +68,7 @@ fi
 # rebuild shortcut:
 
 if [[ "${opt_rebuild}" == "1" ]]; then
+    # Each project must be listed after any project it depends on.
     bash build/zlib.sh       --no-init
     bash build/bzip2.sh      --no-init
     bash build/libarchive.sh --no-init
@@ -75,6 +76,7 @@ if [[ "${opt_rebuild}" == "1" ]]; then
     bash build/libpng.sh     --no-init
     bash build/freetype.sh   --no-init
     bash build/libcxx.sh     --no-init
+    #bash build/glog.sh       --no-init
     bash build/targets.sh    --no-init
     exit
 fi
@@ -410,17 +412,18 @@ export LDFLAGS="${ldflags}"
 export SANITIZER="${llvm_sanitizer}"
 export CMAKE_DRIVER_EXE_NAME="${driver_name}"
 
-if [[ "${build_glog}" == "y" ]]; then
-    bash "build/glog.sh"
-fi
-
-bash "build/libarchive.sh"
+# Each project must be listed after any project it depends on.
 bash "build/zlib.sh"
-bash "build/libpng.sh"
-bash "build/brotli.sh"
 bash "build/bzip2.sh"
+bash "build/libarchive.sh"
+bash "build/brotli.sh"
+bash "build/libpng.sh"
 bash "build/freetype.sh"
 LDFLAGS= bash "build/libcxx.sh"
+if [[ "${build_glog}" == "y" ]]; then
+    #TODO: use the static libcxx
+    bash "build/glog.sh"
+fi
 bash "build/targets.sh"
 
 cd "${dir}"


### PR DESCRIPTION
Add missing submodules and consistently check for the existence of build
files and build in the correct directory.