### PR TITLE
Drop support for git <= 2.14.

### DIFF
--- a/fuzzing/scripts/build/brotli.sh
+++ b/fuzzing/scripts/build/brotli.sh
@@ -18,7 +18,7 @@ path_to_build="${path_to_src}/build"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 
-    git submodule update --init "${path_to_src}"
+    git submodule update --init --depth 1 "${path_to_src}"
 
     cd "${path_to_src}"
 

--- a/fuzzing/scripts/build/bzip2.sh
+++ b/fuzzing/scripts/build/bzip2.sh
@@ -17,7 +17,7 @@ path_to_src=$( readlink -f "../../../external/bzip2" )
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 
-    git submodule update --init "${path_to_src}"
+    git submodule update --init --depth 1 "${path_to_src}"
 
     cd "${path_to_src}"
 

--- a/fuzzing/scripts/build/glog.sh
+++ b/fuzzing/scripts/build/glog.sh
@@ -18,14 +18,7 @@ path_to_build="${path_to_src}/build"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 
-    # It's tempting to add `--depth 1' in `git submodule update' but sadly,
-    # `git <= 2.14' does not understand its purpose correctly when working
-    # with tags or commits that are not most recent.  Setting `--depth 1'
-    # conditionally, based on the installed version of `git', is possible and
-    # would save some time when updating submodule.  #goodFirstIssue
-
-    git submodule init   "${path_to_src}"
-    git submodule update "${path_to_src}"
+    git submodule update --init --depth 1 "${path_to_src}"
 
     cd "${path_to_src}"
 

--- a/fuzzing/scripts/build/libarchive.sh
+++ b/fuzzing/scripts/build/libarchive.sh
@@ -17,13 +17,7 @@ path_to_src=$( readlink -f "../../../external/libarchive" )
 
 if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
 
-    # It's tempting to add `--depth 1' in `git submodule update' but sadly,
-    # `git <= 2.14' does not understand its purpose correctly when working
-    # with tags or commits that are not most recent.  Setting `--depth 1'
-    # conditionally, based on the installed version of `git', is possible and
-    # would save some time when updating submodule.  #goodFirstIssue
-
-    git submodule update --init "${path_to_src}"
+    git submodule update --init --depth 1 "${path_to_src}"
 
     cd "${path_to_src}"
 

--- a/fuzzing/scripts/build/libpng.sh
+++ b/fuzzing/scripts/build/libpng.sh
@@ -21,7 +21,7 @@ path_to_install="${path_to_src}/usr"
 
 if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
 
-    git submodule update --init "${path_to_src}"
+    git submodule update --init --depth 1 "${path_to_src}"
 
     cd "${path_to_src}"
 

--- a/fuzzing/scripts/build/zlib.sh
+++ b/fuzzing/scripts/build/zlib.sh
@@ -20,7 +20,7 @@ path_to_install="${path_to_src}/usr"
 
 if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
 
-    git submodule update --init "${path_to_src}"
+    git submodule update --init --depth 1 "${path_to_src}"
 
     cd "${path_to_src}"
 


### PR DESCRIPTION
The oss-fuzz project recently updated their base image from Ubuntu 16.04
to Ubuntu 20.04, so there should no longer be any need to support git <
2.25. This means that submodules should now be better behaved.