### PR TITLE
Use sanitize-coverage=0 not no-sanitize-coverage

### DIFF
--- a/fuzzing/scripts/build/0001-Add-trace-pc-guard-to-fno-sanitize-coverage.patch
+++ b/fuzzing/scripts/build/0001-Add-trace-pc-guard-to-fno-sanitize-coverage.patch
@@ -4,6 +4,8 @@ Date: Fri, 17 Dec 2021 23:12:05 -0500
 Subject: [PATCH] Add trace-pc-guard to -fno-sanitize-coverage.
 
 This allows libcxx, libcxxabi, and libunwind to be built with HonggFuzz.
+The '-fsanitize-coverage=0' to disable all sanitize-coverage options is
+undocumented but tested by clang.
 ---
  libcxx/cmake/config-ix.cmake    | 2 +-
  libcxxabi/cmake/config-ix.cmake | 2 +-
@@ -19,7 +21,7 @@ index a2f1ff9f1a3b..91b1749c75af 100644
    endif ()
    if (CMAKE_C_FLAGS MATCHES -fsanitize-coverage OR CMAKE_CXX_FLAGS MATCHES -fsanitize-coverage)
 -    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fno-sanitize-coverage=edge,trace-cmp,indirect-calls,8bit-counters")
-+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fno-sanitize-coverage=trace-pc-guard,edge,trace-cmp,indirect-calls,8bit-counters")
++    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fsanitize-coverage=0")
    endif ()
  endif ()
  
@@ -32,7 +34,7 @@ index 7f1cecbcd254..86370a712220 100644
    endif ()
    if (CMAKE_C_FLAGS MATCHES -fsanitize-coverage OR CMAKE_CXX_FLAGS MATCHES -fsanitize-coverage)
 -    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fno-sanitize-coverage=edge,trace-cmp,indirect-calls,8bit-counters")
-+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fno-sanitize-coverage=trace-pc-guard,edge,trace-cmp,indirect-calls,8bit-counters")
++    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fsanitize-coverage=0")
    endif ()
  endif ()
  
@@ -45,7 +47,7 @@ index 4ca6bdd8e95d..34381fbd8721 100644
    endif ()
    if (CMAKE_C_FLAGS MATCHES -fsanitize-coverage OR CMAKE_CXX_FLAGS MATCHES -fsanitize-coverage)
 -    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fno-sanitize-coverage=edge,trace-cmp,indirect-calls,8bit-counters")
-+    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fno-sanitize-coverage=trace-pc-guard,edge,trace-cmp,indirect-calls,8bit-counters")
++    set(CMAKE_REQUIRED_FLAGS "${CMAKE_REQUIRED_FLAGS} -fsanitize-coverage=0")
    endif ()
  endif ()
  


### PR DESCRIPTION
Use '-fsanitize-coverage=0' to disable all sanitize-coverage options.
This is undocumented but tested by clang.