### PR TITLE
Remove CMAKE_x_COMPILER from libcxx build.

### DIFF
--- a/fuzzing/scripts/build/libcxx.sh
+++ b/fuzzing/scripts/build/libcxx.sh
@@ -46,8 +46,6 @@ if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
       -GNinja ../llvm \
       -DCMAKE_BUILD_TYPE=Release \
       -DLLVM_ENABLE_PROJECTS="libcxx;libcxxabi" \
-      -DCMAKE_C_COMPILER="${CC}" \
-      -DCMAKE_CXX_COMPILER="${CXX}" \
       -DLLVM_USE_SANITIZER="${LLVM_SANITIZER}" \
       -DLIBCXX_ENABLE_SHARED=OFF \
       -DLIBCXXABI_ENABLE_SHARED=OFF


### PR DESCRIPTION
The environment variable CC and CXX are not compatible in any way with
CMAKE_x_COMPILER and should not be used to set it. CMAKE_x_COMPILER is
expected by CMake to be the absolute path to the compiler (and not any
compiler wrapper). The blessed way to use a compiler wrapper with CMake
is to specify it with CMAKE_x_COMPILER_LAUNCHER.

Internally, CMake makes itself compatible with CC and CXX environment
variables by splitting the environment variable and assigning the first
part to CMAKE_x_COMPILER and the rest to the undocumented internal
CMAKE_x_COMPILER_ARG1. Essentially this means treating 'ccache' as the
compiler and 'cmake' as a mandatory first parameter. This mostly works
except for the various places where CMake doesn't actually pass the
mandatory first parameter, like when checking to see if the compiler
also doubles as an assembler.

CMAKE_x_COMPILER was only being set here this way because that was how
the oss-fuzz llvm project build files were set up. However, this is
incorrect. By simply removing these lines CMake will properly use the
environment variables.

Fixes: #118