### PR TITLE
Build bzip2 correctly.

### DIFF
--- a/fuzzing/scripts/build/0001-Don-t-override-CC-CFLAGS-and-LDFLAGS.patch
+++ b/fuzzing/scripts/build/0001-Don-t-override-CC-CFLAGS-and-LDFLAGS.patch
@@ -1,0 +1,39 @@
+From f5159ca4c55f1071fccc97fbdaa7561be5315b2f Mon Sep 17 00:00:00 2001
+From: Ben Wagner <bungeman@chromium.org>
+Date: Fri, 7 Jan 2022 12:15:51 -0500
+Subject: [PATCH] Don't override CC, CFLAGS, and LDFLAGS.
+
+The bzip2 build is quite simple and does not use autotools for
+configuration. The simple Makefile provided overrides CC, CFLAGS, and
+LDFLAGS which means it cannot be cross compiled or fuzzed. Use the user
+supplied flags to allow build modification.
+---
+ Makefile | 12 ++++--------
+ 1 file changed, 4 insertions(+), 8 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index b0fef95..8d64b20 100644
+--- a/Makefile
++++ b/Makefile
+@@ -14,14 +14,10 @@
+ 
+ SHELL=/bin/sh
+ 
+-# To assist in cross-compiling
+-CC=gcc
+-AR=ar
+-RANLIB=ranlib
+-LDFLAGS=
+-
+-BIGFILES=-D_FILE_OFFSET_BITS=64
+-CFLAGS=-Wall -Winline -O2 -g $(BIGFILES)
++RANLIB ?= ranlib
++
++BIGFILES = -D_FILE_OFFSET_BITS=64
++CFLAGS := ${CFLAGS} $(BIGFILES)
+ 
+ # Where you want it installed when you do 'make install'
+ PREFIX=/usr/local
+-- 
+2.34.1.575.g55b058a8bb-goog
+

--- a/fuzzing/scripts/build/bzip2.sh
+++ b/fuzzing/scripts/build/bzip2.sh
@@ -11,9 +11,10 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
+path_to_self="$( dirname "$( readlink -f "${0}" )" )"
+cd "${path_to_self}" # go to `/fuzzing/scripts/build'
 
-path_to_src=$( readlink -f "../../../external/bzip2" )
+path_to_src="$( readlink -f "../../../external/bzip2" )"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 
@@ -24,6 +25,10 @@ if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
     git clean -dfqx
     git reset --hard
     git rev-parse HEAD
+
+    # The bzip Makefile overrides CC, CFLAGS, and LDFLAGS.
+    # Patch out these overrides.
+    git apply "${path_to_self}/0001-Don-t-override-CC-CFLAGS-and-LDFLAGS.patch"
 fi
 
 if [[ -f "${path_to_src}/Makefile" ]]; then


### PR DESCRIPTION
The bzip2 build is just a simple Makefile which overrides CC, CFLAGS,
and LDFLAGS. Patch up the Makefile not to do that. Note that the
oss-fuzz bzip2 build does not use the Makefile at all, instead manually
building and linking in the build.sh.

This change allows the i386 oss-fuzz configuration to work.