### PR TITLE
Quote more strings.

### DIFF
--- a/fuzzing/scripts/build/brotli.sh
+++ b/fuzzing/scripts/build/brotli.sh
@@ -11,9 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
+cd "$( dirname "$( readlink -f "${0}" )" )" # go to `/fuzzing/scripts/build'
 
-path_to_src=$( readlink -f "../../../external/brotli" )
+path_to_src="$( readlink -f "../../../external/brotli" )"
 path_to_build="${path_to_src}/build"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then

--- a/fuzzing/scripts/build/freetype.sh
+++ b/fuzzing/scripts/build/freetype.sh
@@ -11,9 +11,9 @@ set -exo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
+cd "$( dirname "$( readlink -f "${0}" )" )" # go to `/fuzzing/scripts/build'
 
-path_to_freetype=$( readlink -f "../../../external/freetype2" )
+path_to_freetype="$( readlink -f "../../../external/freetype2" )"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 

--- a/fuzzing/scripts/build/glog.sh
+++ b/fuzzing/scripts/build/glog.sh
@@ -11,9 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
+cd "$( dirname "$( readlink -f "${0}" )" )" # go to `/fuzzing/scripts/build'
 
-path_to_src=$( readlink -f "../../../external/glog" )
+path_to_src="$( readlink -f "../../../external/glog" )"
 path_to_build="${path_to_src}/build"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then

--- a/fuzzing/scripts/build/libarchive.sh
+++ b/fuzzing/scripts/build/libarchive.sh
@@ -11,9 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
+cd "$( dirname "$( readlink -f "${0}" )" )" # go to `/fuzzing/scripts/build'
 
-path_to_src=$( readlink -f "../../../external/libarchive" )
+path_to_src="$( readlink -f "../../../external/libarchive" )"
 
 if [[ "${#}" -lt "1" || "${1}" != "--no-init" ]]; then
 

--- a/fuzzing/scripts/build/libcxx.sh
+++ b/fuzzing/scripts/build/libcxx.sh
@@ -11,10 +11,10 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-path_to_self=$( dirname $( readlink -f "${0}" ) )
+path_to_self="$( dirname "$( readlink -f "${0}" )" )"
 cd "${path_to_self}" # go to `/fuzzing/scripts/build'
 
-path_to_src=$( readlink -f "../../../external/llvm-project" )
+path_to_src="$( readlink -f "../../../external/llvm-project" )"
 path_to_build="${path_to_src}/build"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
@@ -28,6 +28,7 @@ if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
     git rev-parse HEAD
 
     # See https://github.com/google/oss-fuzz/pull/7033
+    # See https://reviews.llvm.org/D116050
     git apply "${path_to_self}/0001-Add-trace-pc-guard-to-fno-sanitize-coverage.patch"
 
     mkdir "${path_to_build}" && cd "${path_to_build}"

--- a/fuzzing/scripts/build/libpng.sh
+++ b/fuzzing/scripts/build/libpng.sh
@@ -11,11 +11,11 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
+cd "$( dirname "$( readlink -f "${0}" )" )" # go to `/fuzzing/scripts/build'
 
-path_to_zlib=$( readlink -f "../../../external/zlib" )
+path_to_zlib="$( readlink -f "../../../external/zlib" )"
 
-path_to_src=$( readlink -f "../../../external/libpng" )
+path_to_src="$( readlink -f "../../../external/libpng" )"
 path_to_build="${path_to_src}/build"
 path_to_install="${path_to_src}/usr"
 

--- a/fuzzing/scripts/build/targets.sh
+++ b/fuzzing/scripts/build/targets.sh
@@ -11,9 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
+cd "$( dirname "$( readlink -f "${0}" )" )" # go to `/fuzzing/scripts/build'
 
-path_to_build=$( readlink -f "../../build" )
+path_to_build="$( readlink -f "../../build" )"
 
 if [[ "${#}" == "0" || "${1}" != "--no-init" ]]; then
 

--- a/fuzzing/scripts/build/zlib.sh
+++ b/fuzzing/scripts/build/zlib.sh
@@ -11,9 +11,9 @@ set -euxo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts/build'
+cd "$( dirname "$( readlink -f "${0}" )" )" # go to `/fuzzing/scripts/build'
 
-path_to_src=$( readlink -f "../../../external/zlib" )
+path_to_src="$( readlink -f "../../../external/zlib" )"
 # Cannot do out of source build with zprefix, too many zconf.h
 path_to_build="${path_to_src}"
 path_to_install="${path_to_src}/usr"

--- a/fuzzing/scripts/custom-build.sh
+++ b/fuzzing/scripts/custom-build.sh
@@ -11,7 +11,7 @@ set -eo pipefail
 # fully.
 
 dir="${PWD}"
-cd $( dirname $( readlink -f "${0}" ) ) # go to `/fuzzing/scripts'
+cd "$( dirname "$( readlink -f "${0}" )" )" # go to `/fuzzing/scripts'
 
 # ----------------------------------------------------------------------------
 # collect parameters:


### PR DESCRIPTION
Properly quoting in these scripts allows them to run properly even if
there are spaces in the path. Note that while these scripts will work
properly, the actual build does not, since (at least) the zlib install
target will not correctly install to a path with spaces.