### PR TITLE
Unquote cc and cxx when executing.

### DIFF
--- a/fuzzing/scripts/custom-build.sh
+++ b/fuzzing/scripts/custom-build.sh
@@ -227,7 +227,7 @@ else
     cc="clang"
 fi
 print_info "cc" "${cc}"
-cc_version_output=$("${cc}" --version)
+cc_version_output=$(${cc} --version)
 if [[ "${cc_version_output}" =~ ${clang_version_regex} ]]; then
     cc_version="${BASH_REMATCH[1]}"
     print_info "cc version" "${cc_version}"
@@ -241,7 +241,7 @@ else
     cxx="clang++"
 fi
 print_info "cxx" "${cxx}"
-cxx_version_output=$("${cxx}" --version)
+cxx_version_output=$(${cxx} --version)
 if [[ "${cxx_version_output}" =~ ${clang_version_regex} ]]; then
     cxx_version="${BASH_REMATCH[1]}"
     print_info "cxx version" "${cxx_version}"


### PR DESCRIPTION
When running cc and cxx to ensure they exist and get their version, do
not quote them as if they were paths but allow them to expand as they
normally would. This allows the compiler to be specified as "ccache
clang" when using ccache or even "clang-11 --driver-mode=g++" when
needing to use a non-default clang++.