### PR TITLE
Add missing #include to fix C++20 compile error.

### DIFF
--- a/fuzzing/src/visitors/facevisitor-charcodes.h
+++ b/fuzzing/src/visitors/facevisitor-charcodes.h
@@ -18,6 +18,7 @@
 #define VISITORS_FACE_VISITOR_CHARCODES_H_
 
 
+#include <string>
 #include <utility> // std::pair
 #include <vector>
 


### PR DESCRIPTION
Bug: chromium:1284275