### PR TITLE
Initialize master pointers to nullptr

### DIFF
--- a/fuzzing/src/iterators/faceprepiterator-multiplemasters.cpp
+++ b/fuzzing/src/iterators/faceprepiterator-multiplemasters.cpp
@@ -28,7 +28,7 @@
       FacePrepIteratorOutlines::get_prepared_face( face_loader, index );
 
     FT_Library             library;
-    FT_MM_Var*             master;
+    FT_MM_Var*             master = nullptr;
     std::vector<FT_Fixed>  coords;
 
 

--- a/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
+++ b/fuzzing/src/visitors/facevisitor-multiplemasters.cpp
@@ -33,7 +33,7 @@
 
     FT_Library       library;
     FT_Multi_Master  master;
-    FT_MM_Var*       var;
+    FT_MM_Var*       var = nullptr;
 
     std::vector<FT_Long>   coords_mm_design;
     std::vector<FT_Fixed>  coords_var_design;


### PR DESCRIPTION
If FT_Get_MM_Var fails, the fuzzer runs into double-free's otherwise.

Part 2 of fixing [1].

[1] https://bugs.chromium.org/p/chromium/issues/detail?id=1360295