### PR TITLE
Update ftoption.patch

### DIFF
--- a/fuzzing/settings/freetype2/ftoption.patch
+++ b/fuzzing/settings/freetype2/ftoption.patch
@@ -1,8 +1,8 @@
 diff --git a/include/freetype/config/ftoption.h b/include/freetype/config/ftoption.h
-index 18dc4669..3491225a 100644
+index 1976b33..23254e6 100644
 --- a/include/freetype/config/ftoption.h
 +++ b/include/freetype/config/ftoption.h
-@@ -503,7 +503,7 @@ FT_BEGIN_HEADER
+@@ -551,7 +551,7 @@ FT_BEGIN_HEADER
     *
     *   More details can be found in the file `fterrors.h`.
     */
@@ -11,18 +11,7 @@ index 18dc4669..3491225a 100644
  
  
    /*************************************************************************/
-@@ -658,8 +658,8 @@ FT_BEGIN_HEADER
-    * https://www.microsoft.com/typography/cleartype/truetypecleartype.aspx
-    */
- /* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  1         */
--#define TT_CONFIG_OPTION_SUBPIXEL_HINTING  2
--/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  ( 1 | 2 ) */
-+/* #define TT_CONFIG_OPTION_SUBPIXEL_HINTING  2         */
-+#define TT_CONFIG_OPTION_SUBPIXEL_HINTING  ( 1 | 2 )
- 
- 
-   /**************************************************************************
-@@ -778,7 +778,7 @@ FT_BEGIN_HEADER
+@@ -818,7 +818,7 @@ FT_BEGIN_HEADER
     * switch between the two engines using the `hinting-engine` property of
     * the 'type1' driver module.
     */
@@ -31,7 +20,7 @@ index 18dc4669..3491225a 100644
  
  
    /*************************************************************************/
-@@ -820,7 +820,7 @@ FT_BEGIN_HEADER
+@@ -860,7 +860,7 @@ FT_BEGIN_HEADER
     * between the two engines using the `hinting-engine` property of the 'cff'
     * driver module.
     */


### PR DESCRIPTION
TT_CONFIG_OPTION_SUBPIXEL_HINTING has changed and is back to being a simple define instead of having a value which is a set of flags. Update the patch for this setting so that the patch can be cleanly applied to versions of FreeType after "[truetype] Hide Infinality." [0].

[0] bbfcd79eacb4985d4b68783565f4b494aa64516b