### PR TITLE
Check for outlines instead of asserting

### DIFF
--- a/fuzzing/src/visitors/glyphvisitor-outlines.cpp
+++ b/fuzzing/src/visitors/glyphvisitor-outlines.cpp
@@ -42,8 +42,9 @@
     FT_Outline*  glyph_outline;
 
 
-    assert( glyph         != nullptr                 &&
-            glyph->format == FT_GLYPH_FORMAT_OUTLINE );
+    assert( glyph != nullptr );
+    if ( glyph->format != FT_GLYPH_FORMAT_OUTLINE )
+      return;
 
     glyph_outline = &( (FT_OutlineGlyph)glyph.get() )->outline;
 


### PR DESCRIPTION
The outline fuzzer was relying on the use of FT_LOAD_NO_BITMAP in "GlyphsOutlinesFuzzTarget()" [0] to produce only glyphs with FT_GLYPH_FORMAT_OUTLINE to satisfy the assert in
"GlyphVisitorOutlines::run" [1].  This was never really true, but with "[truetype] Ingnore FT_LOAD_NO_BITMAP in bitmap-only fonts." [2] this is now very often false.  Because this assert could have been hit already, remove the assert that the glyph has an outline and instead return early if there is no outline.

[0] https://github.com/freetype/freetype2-testing/blob/57d875f1c45b5c9b83bf2e99cedc150108a2b28c/fuzzing/src/targets/glyphs/outlines.cpp#L47
[1] https://github.com/freetype/freetype2-testing/blob/57d875f1c45b5c9b83bf2e99cedc150108a2b28c/fuzzing/src/visitors/glyphvisitor-outlines.cpp#L46
[2] https://gitlab.freedesktop.org/freetype/freetype/-/commit/4ef8eed11b719409d9fc284fb80d886e5bd0b28f

Bug: https://issues.chromium.org/issues/385224946