### PR TITLE
Add missing include headers

### DIFF
--- a/fuzzing/src/utils/tarreader.h
+++ b/fuzzing/src/utils/tarreader.h
@@ -15,6 +15,8 @@
 #ifndef UTILS_TAR_READER_H_
 #define UTILS_TAR_READER_H_
 
+#include <stdint.h>
+
 #include <vector>
 
 #include <ft2build.h>

--- a/fuzzing/src/utils/utils.h
+++ b/fuzzing/src/utils/utils.h
@@ -27,6 +27,7 @@
 
 
 #include <memory>
+#include <utility>
 
 #include <ft2build.h>
 #include FT_FREETYPE_H


### PR DESCRIPTION
This is for C++ modules build in chromium.